### PR TITLE
Sprint 2 — DNS + network resilience

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -21,3 +21,8 @@ Completed: Full sensitive-information sweep. Working tree clean; all `secrets/te
 Output: `files/review/bishop-security.md`. Security decisions + rotation actions merged into `decisions.md`. GitHub milestone #1 now tracks 32 issues (#22–#53).
 
 Continuity: Agent history updated. Credentials rotation required before next production push.
+
+
+## Sprint 1 (CI/HA Baseline) — Completion Note (2026-06-26)
+
+**PR #55 merged.** Security findings documented. Credentials rotation P1 for next session. validator.sh false-positive fix (issue #32) completed; `.copilot/` and `.squad/` added to path-skip.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -32,3 +32,8 @@ Existing-issue triage completed and results merged into decisions.md. Coordinato
 - **#18** Diun image update notifications (P3)
 
 Coordination point: also owns `.env.sample` rewrite decision (decision #4, P1 — coordinate with Lambert). No sprint contention on Feature Backlog.
+
+
+## Sprint 1 (CI/HA Baseline) — Completion Note (2026-06-26)
+
+**PR #55 merged.** DNS/storage/networking review complete. Longhorn: backup/trim jobs gap identified (daily-backup + weekly-trim needed); default config (replicas=3, Retain) correct. Pi-hole: critical findings: pin versions (pihole v5/v6 incompatibility), add Orbital Sync CronJob, add TLS to admin ingresses; dnsdist PDB minAvailable raised to 2 (issues #26, #33–#36, #39). Feature Backlog: 5 issues promoted (#11, #13, #15, #18 + existing). .env.sample rewrite coordination point with Lambert. Ready for next platform hardening sprint.

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -21,3 +21,8 @@ Completed: Assembled committed review documents from ripley, parker, dallas, bis
 Output: Two committed docs + consolidated follow-up list. Review completion merged into `decisions.md`. GitHub milestone #1 now tracks 32 issues (#22–#53).
 
 Continuity: Agent history updated. Docs delivery complete; ready for next session sprint on platform/app hardening.
+
+
+## Sprint 1 (CI/HA Baseline) — Completion Note (2026-06-26)
+
+**PR #55 merged.** Documentation complete: `docs/reviews/` + `docs/hardware-inventory.md` shipped (security-redacted, privacy audit: GREEN). .env.sample rewrite coordinated (issue #47); bootstrap.md ServerSideApply final step documented (issue #47). Review findings consolidated; 45 follow-ups tracked in decisions.md. Ready for next session hardening sprint.

--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -30,3 +30,8 @@ Existing-issue triage completed and results merged into decisions.md. Coordinato
 - **#17** Jamulus Server (P3)
 
 Coordination point: storage role path alignment (decision #3, P1) is a hard gate for `adopt.yml` promotion — validate with Brandon + Dallas before proceeding. Feature Backlog issues are post-hardening scope.
+
+
+## Sprint 1 (CI/HA Baseline) — Completion Note (2026-06-26)
+
+**PR #55 merged.** Hardware inventory extraction complete (rpi001–rpi004 live specs captured). **Critical findings:** rpi003 thermal throttling (78.4 °C, active events) — requires heatsink/fan; rpi001 USB mount undocumented in Ansible. Storage role path-mismatch constraint documented (hard gate: must align `/media/data_ext` + validate before `adopt.yml --allow_disruptive`). Ansible roles OS-conditional cgroup path (Bullseye/Bookworm, issues #50, #51) deployed. Ready for next coordination gate.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -31,3 +31,8 @@ Existing-issue triage completed and results merged into decisions.md. Coordinato
 - **#20** k3s system-upgrade-controller (P3)
 
 No sprint contention; all Feature Backlog issues are post-hardening scope. Ready for pickup when milestone #1 wind-down begins.
+
+
+## Sprint 1 (CI/HA Baseline) — Completion Note (2026-06-26)
+
+**PR #55 merged.** Global GitOps review complete; sync-wave annotation applied to apps ApplicationSet (#25). Triage results recorded. Feature Backlog milestone created; 9 enriched issues promoted (#7, #11, #13–#18, #20). Next: .env.sample rewrite coordination + Traefik CRD verification (decisions #1, #4).

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -123,6 +123,40 @@ Triaged 12 pre-existing open issues against current repo state and 31 new issues
 
 ---
 
+### 7. Hardware Inventory Live-Fill & Thermal/Mount Findings (Parker, 2026-06-26)
+
+**Author:** Parker | **Date:** 2026-06-26 | **Status:** Completed + Action Items Identified
+
+Updated `docs/hardware-inventory.md` with real values gathered live from the cluster (read-only inspection only).
+
+**Per-Node Summary:**
+- rpi001: Pi 4B 8GB, SanDisk SSD PLUS 240GB @ `/media/data_ext` (Docker/k3s, 26% used)
+- rpi002: Pi 4B 4GB, SanDisk Extreme Pro ~256GB @ `/media/data_ext` (Longhorn, 14% used)
+- rpi003: Pi 4B 4GB, SanDisk Extreme Pro ~256GB @ `/media/data_ext` (Longhorn, 30% used)
+- rpi004: Pi 4B 4GB, SanDisk SSD PLUS 240GB @ `/media/data_ext` (Longhorn, 29% used)
+
+All Bullseye (not Bookworm), kernel 6.1.21-v8+, SanDisk SR32G 32GB SD cards.
+
+**CRITICAL — rpi003 Thermal Throttling (NEW-1):**
+- At inspection: **78.4 °C** (threshold ~80 °C), `vcgencmd get_throttled` = `0xe0000` (soft temp limit, arm freq capped, throttling events)
+- rpi003 hosts 5 Longhorn PVCs + Prometheus StatefulSet (25 GB) — heaviest load
+- **Action:** Add heatsink/fan to rpi003 or redistribute Longhorn workloads. Thermal events may cause unnecessary replica timeouts/rebuilds.
+
+**CRITICAL — rpi001 USB Mount Undocumented in Ansible (NEW-2):**
+- rpi001 has `/dev/sda1` at `/media/data_ext` but `group_vars/all.yml` still sets `mount_usb: false`
+- Extends existing F-02 finding to control-plane node. rpi001 USB is NOT Ansible-managed.
+
+**MEDIUM — Inconsistent USB Mount Options (NEW-4):**
+- rpi001/rpi004: `stripe=8191` mount option (manual tune)
+- rpi002/rpi003: plain `rw,nosuid,nodev,relatime`
+- **Action:** Investigate performance impact once mounts are Ansible-managed.
+
+**Confirmed:** Issue #52 (HDD vs SSD) RESOLVED — all drives are SSDs; ROTA quirk is USB-bridge kernel behavior.
+
+**Data Audit:** No secrets, tokens, passwords, serial numbers, MAC addresses, or public IPs in inventory. LAN IPs (192.168.52.x) retained.
+
+---
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/README.md
+++ b/README.md
@@ -44,4 +44,5 @@ ArgoCD starts observed-only: no automated sync is committed initially. See [docs
 - Bootstrap order: [docs/runbooks/bootstrap.md](docs/runbooks/bootstrap.md)
 - Break-glass operations: [docs/runbooks/break-glass.md](docs/runbooks/break-glass.md)
 - Pi-hole migration: [docs/runbooks/pihole-migration.md](docs/runbooks/pihole-migration.md)
+- Pi-hole gravity sync: [docs/runbooks/pihole-gravity-sync.md](docs/runbooks/pihole-gravity-sync.md)
 - Disaster recovery: [docs/runbooks/disaster-recovery.md](docs/runbooks/disaster-recovery.md)

--- a/apps/chrony/service.yml
+++ b/apps/chrony/service.yml
@@ -11,15 +11,28 @@ spec:
       targetPort: 123
       protocol: UDP
 ---
+# The NTP VIP. MetalLB (L2) assigns 192.168.52.54 and announces it from a node
+# that currently runs a ready chrony pod. This is additive to the klipper
+# pattern (see platform/metallb/helm-values.yaml): loadBalancerClass pins this
+# Service to MetalLB, so klipper ignores it and there is no controller collision.
+#
+# OPERATOR ACTION REQUIRED on sync: after ArgoCD syncs this change, point any
+# NTP client or DHCP option that references the old klipper node IPs
+# (192.168.52.110/112) to 192.168.52.54 instead.
 apiVersion: v1
 kind: Service
 metadata:
   name: chrony-ntp-udp
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: "192.168.52.54"
+    metallb.universe.tf/address-pool: ntp-vip
 spec:
+  type: LoadBalancer
+  loadBalancerClass: metallb.io/layer2
+  externalTrafficPolicy: Local
+  ipFamilyPolicy: SingleStack
   ports:
     - name: 123-udp
       port: 123
       targetPort: 123
       protocol: UDP
-  externalTrafficPolicy: Local
-  type: LoadBalancer

--- a/apps/dnsdist/deployment.yml
+++ b/apps/dnsdist/deployment.yml
@@ -65,20 +65,32 @@ spec:
               memory: "256Mi"
               cpu: "500m"
           startupProbe:
-            tcpSocket:
-              port: dns-tcp
+            # No DNS client (dig/drill/nslookup/nc) is shipped in
+            # powerdns/dnsdist-19:1.9.12. Bash IS present; /dev/tcp exercises
+            # the kernel TCP stack to confirm dnsdist is accepting connections.
+            exec:
+              command:
+                - bash
+                - -c
+                - "echo > /dev/tcp/127.0.0.1/53"
             failureThreshold: 30
             periodSeconds: 2
             timeoutSeconds: 3
           readinessProbe:
-            tcpSocket:
-              port: dns-tcp
+            exec:
+              command:
+                - bash
+                - -c
+                - "echo > /dev/tcp/127.0.0.1/53"
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
           livenessProbe:
-            tcpSocket:
-              port: dns-tcp
+            exec:
+              command:
+                - bash
+                - -c
+                - "echo > /dev/tcp/127.0.0.1/53"
             periodSeconds: 30
             timeoutSeconds: 3
             failureThreshold: 5

--- a/apps/pihole/gravity-sync.py
+++ b/apps/pihole/gravity-sync.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Pi-hole v6 gravity sync.
+
+Exports the Teleporter backup from pihole-0 (primary) and restores it to
+pihole-1 and pihole-2 (secondaries) using the Pi-hole v6 REST API.
+
+Pi-hole v6 API flow:
+  POST   /api/auth       {"password": "..."} → session.sid
+  GET    /api/teleporter sid:<SID>           → tar.gz binary (gravity + config)
+  POST   /api/teleporter sid:<SID>           → multipart file restore
+  DELETE /api/auth       sid:<SID>           → logout
+
+NOTE: Orbital Sync (ghcr.io/mattwebbio/orbital-sync) was the preferred tool but
+was archived March 2025 without Pi-hole v6 support. This script replicates its
+function directly against the v6 API using only Python stdlib.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+NAMESPACE = "pihole"
+HEADLESS_SVC = "pihole"
+CLUSTER_DOMAIN = "svc.cluster.local"
+
+PRIMARY_HOST = f"pihole-0.{HEADLESS_SVC}.{NAMESPACE}.{CLUSTER_DOMAIN}"
+SECONDARY_HOSTS = [
+    f"pihole-1.{HEADLESS_SVC}.{NAMESPACE}.{CLUSTER_DOMAIN}",
+    f"pihole-2.{HEADLESS_SVC}.{NAMESPACE}.{CLUSTER_DOMAIN}",
+]
+
+PASSWORD = os.environ["PIHOLE_PASSWORD"]
+
+
+def api(host: str, path: str) -> str:
+    return f"http://{host}/api/{path}"
+
+
+def authenticate(host: str) -> str:
+    """POST /api/auth → return session SID."""
+    body = json.dumps({"password": PASSWORD}).encode()
+    req = urllib.request.Request(
+        api(host, "auth"),
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read())
+    sid = data["session"]["sid"]
+    print(f"  auth {host}: sid={sid[:8]}...", flush=True)
+    return sid
+
+
+def logout(host: str, sid: str) -> None:
+    """DELETE /api/auth — best-effort, never raises."""
+    req = urllib.request.Request(
+        api(host, "auth"),
+        method="DELETE",
+        headers={"sid": sid},
+    )
+    try:
+        urllib.request.urlopen(req, timeout=10)
+    except Exception as exc:
+        print(f"  WARN logout {host}: {exc}", flush=True)
+
+
+def export_backup(host: str, sid: str) -> bytes:
+    """GET /api/teleporter → tar.gz binary."""
+    req = urllib.request.Request(
+        api(host, "teleporter"),
+        headers={"sid": sid},
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = resp.read()
+    print(f"  exported {len(data)} bytes from {host}", flush=True)
+    return data
+
+
+def import_backup(host: str, sid: str, backup: bytes) -> None:
+    """POST /api/teleporter with multipart file."""
+    boundary = "PiholeGravitySync42"
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="file"; filename="gravity.tar.gz"\r\n'
+        "Content-Type: application/gzip\r\n"
+        "\r\n"
+    ).encode() + backup + f"\r\n--{boundary}--\r\n".encode()
+    req = urllib.request.Request(
+        api(host, "teleporter"),
+        data=body,
+        method="POST",
+        headers={
+            "sid": sid,
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        result = json.loads(resp.read())
+    print(f"  imported to {host}: {result}", flush=True)
+
+
+def main() -> None:
+    print(f"Pi-hole gravity sync: primary={PRIMARY_HOST}", flush=True)
+
+    primary_sid = authenticate(PRIMARY_HOST)
+    try:
+        backup = export_backup(PRIMARY_HOST, primary_sid)
+    finally:
+        logout(PRIMARY_HOST, primary_sid)
+
+    errors: list[tuple[str, Exception]] = []
+    for host in SECONDARY_HOSTS:
+        print(f"Syncing to {host}", flush=True)
+        try:
+            sid = authenticate(host)
+            try:
+                import_backup(host, sid, backup)
+            finally:
+                logout(host, sid)
+        except Exception as exc:
+            print(f"  ERROR: {exc}", flush=True)
+            errors.append((host, exc))
+
+    if errors:
+        failed = [h for h, _ in errors]
+        print(f"Sync FAILED for: {failed}", flush=True)
+        sys.exit(1)
+    print("Sync complete.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/pihole/gravity-sync.yml
+++ b/apps/pihole/gravity-sync.yml
@@ -1,0 +1,64 @@
+# Gravity sync CronJob: pulls the Pi-hole v6 Teleporter backup from pihole-0
+# (primary) and restores it to pihole-1 and pihole-2 (secondaries) every 6h.
+#
+# WHY NOT Orbital Sync: ghcr.io/mattwebbio/orbital-sync was archived March 2025
+# without Pi-hole v6 support. This CronJob replaces it using the v6 REST API
+# directly (see gravity-sync.py in the pihole-gravity-sync-script ConfigMap).
+#
+# OPERATOR INIT STEPS (for Lambert: document in #48):
+#   On first-sync or after a pod is recreated from scratch, run the CronJob
+#   manually to seed the new pod's gravity database before traffic reaches it:
+#     kubectl create job -n pihole gravity-sync-manual \
+#       --from=cronjob/pihole-gravity-sync
+#     kubectl wait -n pihole --for=condition=Complete job/gravity-sync-manual \
+#       --timeout=120s
+#     kubectl delete job -n pihole gravity-sync-manual
+#   The Pi-hole readinessProbe gates pod traffic on DNS functioning, so a replica
+#   with an empty gravity database is safe but will not block any ads until the
+#   sync completes and gravity is loaded (FTL restart happens automatically after
+#   the Teleporter import).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pihole-gravity-sync
+spec:
+  # Every 6 hours keeps replicas within hours of the primary's blocklists.
+  schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: gravity-sync
+              # python:3.12-alpine3.21 — multi-arch (linux/arm64 for RPi 4B),
+              # stdlib-only (no pip install needed), minimal image.
+              image: python:3.12-alpine3.21
+              command:
+                - python3
+                - /scripts/sync.py
+              env:
+                - name: PIHOLE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: pihole-secret
+                      key: FTLCONF_webserver_api_password
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+              resources:
+                requests:
+                  memory: "32Mi"
+                  cpu: "10m"
+                limits:
+                  memory: "64Mi"
+                  cpu: "100m"
+          volumes:
+            - name: scripts
+              configMap:
+                name: pihole-gravity-sync-script

--- a/apps/pihole/ingress.yml
+++ b/apps/pihole/ingress.yml
@@ -3,7 +3,10 @@ kind: Ingress
 metadata:
   name: pihole-ingress
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: security-redirect-https@kubernetescrd
     cluster-config/suffix-host: "true"
+    cluster-config/suffix-tls: "true"
 spec:
   ingressClassName: traefik
   rules:
@@ -24,13 +27,20 @@ spec:
                 name: pihole-ui-svc
                 port:
                   name: 80-tcp
+  tls:
+    - secretName: pihole-tls
+      hosts:
+        - pihole.SUFFIX
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: pihole-0-ingress
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: security-redirect-https@kubernetescrd
     cluster-config/suffix-host: "true"
+    cluster-config/suffix-tls: "true"
 spec:
   ingressClassName: traefik
   rules:
@@ -51,13 +61,20 @@ spec:
                 name: pihole-0-ui-svc
                 port:
                   name: 80-tcp
+  tls:
+    - secretName: pihole-0-tls
+      hosts:
+        - pihole-0.SUFFIX
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: pihole-1-ingress
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: security-redirect-https@kubernetescrd
     cluster-config/suffix-host: "true"
+    cluster-config/suffix-tls: "true"
 spec:
   ingressClassName: traefik
   rules:
@@ -78,13 +95,20 @@ spec:
                 name: pihole-1-ui-svc
                 port:
                   name: 80-tcp
+  tls:
+    - secretName: pihole-1-tls
+      hosts:
+        - pihole-1.SUFFIX
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: pihole-2-ingress
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: security-redirect-https@kubernetescrd
     cluster-config/suffix-host: "true"
+    cluster-config/suffix-tls: "true"
 spec:
   ingressClassName: traefik
   rules:
@@ -105,3 +129,7 @@ spec:
                 name: pihole-2-ui-svc
                 port:
                   name: 80-tcp
+  tls:
+    - secretName: pihole-2-tls
+      hosts:
+        - pihole-2.SUFFIX

--- a/apps/pihole/kustomization.yml
+++ b/apps/pihole/kustomization.yml
@@ -16,6 +16,11 @@ configMapGenerator:
   - name: pihole-configmap
     envs:
       - .env
+  - name: pihole-gravity-sync-script
+    options:
+      disableNameSuffixHash: true
+    files:
+      - sync.py=gravity-sync.py
 
 resources:
   - namespace.yml
@@ -24,3 +29,4 @@ resources:
   - headless-service.yml
   - poddisruptionbudget.yml
   - ingress.yml
+  - gravity-sync.yml

--- a/apps/pihole/service.yml
+++ b/apps/pihole/service.yml
@@ -61,36 +61,3 @@ spec:
       port: 53
       targetPort: 53
       protocol: UDP
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: pihole-dns-udp
-spec:
-  ports:
-    - name: 53-udp
-      port: 53
-      targetPort: 53
-      protocol: UDP
-  externalTrafficPolicy: Cluster
-  type: LoadBalancer
----
-# House DNS :53 endpoints. Phase 1 matches live exactly: k3s klipper servicelb
-# advertises all node IPs (no loadBalancerIP, externalTrafficPolicy: Cluster), and
-# the UDM-Pro points at those node IPs. Do NOT add loadBalancerIP here while on
-# klipper — it does not match the live network and klipper ignores/mishandles it.
-# Phase 2 (docs/runbooks + rollout-plan): introduce MetalLB with a single VIP,
-# switch to externalTrafficPolicy: Local, and set the VIP via cluster-config
-# lan_lb_ip. See the DNS architecture section of the rollout plan.
-apiVersion: v1
-kind: Service
-metadata:
-  name: pihole-dns-tcp
-spec:
-  ports:
-    - name: 53-tcp
-      port: 53
-      targetPort: 53
-      protocol: TCP
-  externalTrafficPolicy: Cluster
-  type: LoadBalancer

--- a/docs/runbooks/pihole-gravity-sync.md
+++ b/docs/runbooks/pihole-gravity-sync.md
@@ -1,0 +1,200 @@
+# Runbook: Pi-hole gravity sync
+
+Pi-hole's 3-replica StatefulSet uses independent per-pod PVCs. Without active
+synchronization, blocklists (gravity), custom DNS records, whitelists, and
+settings can diverge between pods. Because queries are load-balanced across all
+three, a divergent replica means roughly one-third of DNS queries hit inconsistent
+ad-blocking results.
+
+A custom CronJob — `pihole-gravity-sync` — runs every 6 hours and exports the
+full Teleporter backup from the primary replica (`pihole-0`) and restores it to
+each secondary (`pihole-1`, `pihole-2`).
+
+> **Background:** [Orbital Sync](https://github.com/mattwebbio/orbital-sync) was
+> the preferred tool for this function but was archived in March 2025 without
+> Pi-hole v6 support. This CronJob replicates that function directly against the
+> Pi-hole v6 REST API using a Python stdlib script
+> (`apps/pihole/gravity-sync.py`).
+
+---
+
+## Architecture
+
+### Resources
+
+| Resource | Name | Description |
+|---|---|---|
+| CronJob | `pihole-gravity-sync` | Runs the sync script on a schedule |
+| ConfigMap | `pihole-gravity-sync-script` | Mounts `gravity-sync.py` at `/scripts/sync.py` |
+| Image | `python:3.12-alpine3.21` | Multi-arch (linux/arm64 for RPi 4B), stdlib-only |
+
+Source files: `apps/pihole/gravity-sync.yml`, `apps/pihole/gravity-sync.py`.
+
+### Schedule
+
+```
+0 */6 * * *   (every 6 hours)
+```
+
+`concurrencyPolicy: Forbid` prevents overlapping runs. Up to 3 successful and 3
+failed job records are retained.
+
+### Teleporter API flow
+
+The script uses the **Pi-hole v6 REST API** (Python stdlib only — no pip):
+
+1. **Authenticate** to primary: `POST /api/auth` with the admin password →
+   receives a session SID.
+2. **Export**: `GET /api/teleporter` (with `sid` header) → tar.gz binary
+   containing gravity DB, custom DNS records, whitelists, and settings.
+3. **Logout** primary: `DELETE /api/auth`.
+4. For **each secondary**, in sequence:
+   a. Authenticate → SID.
+   b. **Import**: `POST /api/teleporter` (multipart form) → restores from the
+      tar.gz captured in step 2.
+   c. Logout.
+5. If any secondary import fails, the script exits non-zero (job retries up to 2
+   times per `backoffLimit`).
+
+### Primary / secondary model
+
+| Role | Pod DNS name |
+|---|---|
+| Primary (export source) | `pihole-0.pihole.pihole.svc.cluster.local` |
+| Secondary | `pihole-1.pihole.pihole.svc.cluster.local` |
+| Secondary | `pihole-2.pihole.pihole.svc.cluster.local` |
+
+`pihole-0` is always the source of truth. Changes made on a secondary pod's UI
+will be overwritten on the next sync run.
+
+### Authentication
+
+The admin password is read from the environment variable `PIHOLE_PASSWORD`,
+which is sourced from the `pihole-secret` Secret:
+
+- Secret name: `pihole-secret`
+- Secret key: `FTLCONF_webserver_api_password`
+
+The Secret is pushed (never pulled at runtime) by `scripts/sync-secrets.sh`.
+See [docs/secrets.md](../secrets.md) for the full push-sync model.
+
+---
+
+## Operator init / manual trigger
+
+**When to run this:** After any of these events:
+
+- A Pi-hole pod is recreated from scratch (PVC deleted or node failure with
+  storage loss).
+- Initial cluster bootstrap — the first time all three pods are running but
+  have not yet synced.
+- After manually restoring only `pihole-0` from a backup.
+
+A freshly created pod starts with an empty gravity database. The readinessProbe
+gates DNS traffic on FTL functioning, so the pod will not serve DNS until after
+FTL reloads — which happens automatically after the Teleporter import completes.
+This means the new pod is **safe** (it will not serve stale or empty results to
+clients), but it will not block any ads until the sync finishes.
+
+Run the CronJob as a one-off Job:
+
+```sh
+kubectl create job -n pihole gravity-sync-manual --from=cronjob/pihole-gravity-sync
+kubectl wait -n pihole --for=condition=Complete job/gravity-sync-manual --timeout=120s
+kubectl delete job -n pihole gravity-sync-manual
+```
+
+> If the Job fails (exit non-zero), the pod log will indicate which host failed.
+> See Troubleshooting below before retrying.
+
+---
+
+## Troubleshooting
+
+### View the most recent scheduled sync logs
+
+```sh
+# List recent jobs from the CronJob
+kubectl get jobs -n pihole -l batch.kubernetes.io/controller-uid
+
+# Stream logs from the latest job pod
+kubectl logs -n pihole -l job-name=<job-name> --follow
+```
+
+Or use a label selector to find the pod:
+
+```sh
+kubectl get pods -n pihole -l app=pihole --show-labels
+```
+
+### What a failed authentication looks like
+
+A failed `POST /api/auth` will raise an `urllib.error.HTTPError` (typically
+`HTTP 401 Unauthorized`) and the pod logs will show:
+
+```
+ERROR: HTTP Error 401: Unauthorized
+Sync FAILED for: ['pihole-1.pihole.pihole.svc.cluster.local']
+```
+
+Check that the `pihole-secret` Secret is present and holds the correct value:
+
+```sh
+kubectl get secret -n pihole pihole-secret -o jsonpath='{.data.FTLCONF_webserver_api_password}' | base64 -d
+```
+
+Re-push the Secret if it is missing or stale:
+
+```sh
+scripts/sync-secrets.sh pihole
+```
+
+### Verify gravity counts match across pods
+
+After a successful sync all three pods should report the same gravity domain
+count. Execute the Pi-hole CLI on each pod:
+
+```sh
+for pod in pihole-0 pihole-1 pihole-2; do
+  echo -n "$pod: "
+  kubectl exec -n pihole "$pod" -- pihole -q --all 2>/dev/null | grep -c '^' || \
+  kubectl exec -n pihole "$pod" -- sqlite3 /etc/pihole/gravity.db \
+    "SELECT COUNT(*) FROM gravity;" 2>/dev/null
+done
+```
+
+> **Note:** the exact command to query gravity depends on the Pi-hole version
+> installed in the pod image. Verify the correct invocation against the running
+> image if the above returns an error.
+
+Alternatively, visit the Pi-hole admin UI for each pod via port-forward and
+compare the "Gravity last updated" timestamp and domain count on the dashboard:
+
+```sh
+kubectl port-forward -n pihole pihole-0 8080:80
+kubectl port-forward -n pihole pihole-1 8081:80
+kubectl port-forward -n pihole pihole-2 8082:80
+```
+
+### CronJob not running / missed schedule
+
+```sh
+kubectl describe cronjob -n pihole pihole-gravity-sync
+```
+
+Look for `FailedNeedsStart` or `TooManyMissedSchedules` events. The most common
+causes are a suspended CronJob or clock skew on the controller node.
+
+```sh
+# Check if the CronJob is suspended
+kubectl get cronjob -n pihole pihole-gravity-sync -o jsonpath='{.spec.suspend}'
+```
+
+---
+
+## Related runbooks
+
+- [Pi-hole migration](./pihole-migration.md) — safe deployment order, DNS
+  cutover, and rollback.
+- [Break-glass](./break-glass.md) — push a manifest directly when ArgoCD is
+  unavailable.

--- a/docs/runbooks/pihole-migration.md
+++ b/docs/runbooks/pihole-migration.md
@@ -102,3 +102,11 @@ so its `10.43.100.20` upstream reference does not change.
 5. Reconcile Git with the rollback before enabling automation.
 
 Pi-hole should be promoted to auto-sync/self-heal only after multiple clean syncs and an explicit operator decision.
+
+## Gravity sync after migration
+
+Once all three Pi-hole replicas are running, trigger an initial gravity sync
+immediately so all pods share the same blocklists and settings:
+
+See [pihole-gravity-sync.md](./pihole-gravity-sync.md) for the manual trigger
+procedure and full details of the CronJob architecture.

--- a/platform/metallb/helm-values.yaml
+++ b/platform/metallb/helm-values.yaml
@@ -14,7 +14,9 @@
 # in a later sync wave, after these CRDs exist.
 
 # Pin MetalLB to a dedicated loadBalancerClass so it never fights klipper over
-# the unclassed LoadBalancer Services (chrony, minecraft, legacy pihole DNS).
+# the unclassed LoadBalancer Services (minecraft, legacy pihole DNS).
+# chrony-ntp-udp now uses loadBalancerClass: metallb.io/layer2 (issue #43) and
+# is claimed by MetalLB; only the legacy pihole DNS Services stay on klipper.
 loadBalancerClass: metallb.io/layer2
 
 # CRDs are installed by the chart (IPAddressPool, L2Advertisement, etc.).
@@ -40,6 +42,17 @@ speaker:
   # L2 mode: speaker uses ARP, not FRR/BGP.
   frr:
     enabled: false
+  # Allow the speaker DaemonSet to run on the control-plane node (rpi001) so
+  # the VIP leader pool includes it. Live taints on rpi001:
+  #   node-role.kubernetes.io/master:NoSchedule
+  #   node-role.kubernetes.io/control-plane:NoSchedule
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
   resources:
     requests:
       cpu: 25m

--- a/platform/metallb/ipaddresspool.yml
+++ b/platform/metallb/ipaddresspool.yml
@@ -45,6 +45,29 @@ spec:
     - 192.168.52.80/32
   autoAssign: false
 ---
+# The NTP VIP. A dedicated MetalLB Layer-2 address so chrony is reachable on
+# ONE stable IP (192.168.52.54) that follows pod moves, instead of rotating
+# klipper node IPs. Mnemonic: .54 sits beside .53 (the DNS VIP).
+#
+# Migration note: adding loadBalancerClass to chrony-ntp-udp causes klipper to
+# release it (klipper ignores services with a loadBalancerClass) and MetalLB to
+# claim it. After ArgoCD syncs apps/chrony, update any NTP client configs that
+# pointed to the old klipper node IPs to use 192.168.52.54 instead.
+#
+# Mirror locations (update together):
+#   - platform/metallb/ipaddresspool.yml (this pool)
+#   - platform/metallb/l2advertisement.yml (ntp-vip advertisement)
+#   - apps/chrony/service.yml (loadBalancerIPs on the chrony Service)
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: ntp-vip
+  namespace: metallb-system
+spec:
+  addresses:
+    - 192.168.52.54/32
+  autoAssign: false
+---
 # The Minecraft Bedrock VIP. A dedicated Layer-2 address so the game server is
 # reachable on ONE stable IP that follows the pod across reschedules, instead of
 # the k3s klipper node IP (which changed whenever minecraft-0 moved nodes and

--- a/platform/metallb/l2advertisement.yml
+++ b/platform/metallb/l2advertisement.yml
@@ -26,6 +26,18 @@ spec:
   ipAddressPools:
     - ingress-vip
 ---
+# Announce the NTP VIP pool over Layer 2. With externalTrafficPolicy: Local on
+# chrony-ntp-udp, MetalLB elects a node that runs a ready chrony pod as the
+# ARP leader, giving automatic failover on pod/node failure.
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: ntp-vip
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - ntp-vip
+---
 # Announce the Minecraft VIP pool over Layer 2. The two minecraft Services use
 # externalTrafficPolicy: Local and select the same single pod, so MetalLB
 # announces .81 from whichever node currently runs minecraft-0 and migrates it on


### PR DESCRIPTION
Post-Refactor Hardening **Sprint 2** (milestone "Post-Refactor Review & Hardening"). Additive + GitOps; **no auto-sync** — apps show OutOfSync until you manually sync.

## Validation
`scripts/validate.sh` passes (exit 0): kustomize builds, helm lint, secret scan, prune guard. Each change live-verified where relevant.

## Included
- [x] Closes #24 — Traefik CRD: **verified v2 (`traefik.containo.us`) live; manifests already correct** (no change needed)
- [x] Closes #28 — Pi-hole Ingress TLS + HTTPS redirect (cert-manager `letsencrypt-prod`)
- [x] Closes #27 — Pi-hole gravity sync: custom **Pi-hole v6 teleporter-API CronJob** (Orbital Sync is archived / v6-incompatible)
- [x] Closes #42 — remove legacy klipper Pi-hole DNS LB services (you confirmed UDM-Pro → `.53`)
- [x] Closes #43 — chrony NTP MetalLB VIP `192.168.52.54`
- [x] Closes #44 — MetalLB speaker control-plane tolerations (live taints verified)
- [x] Closes #48 — gravity-sync runbook (`docs/runbooks/pihole-gravity-sync.md`)
- [ ] #40 — dnsdist probe moved to in-container exec on `:53`. **Partial:** the `powerdns/dnsdist` image ships no DNS client (`dig`/`drill`/`nslookup`/`nc` all absent), so a true DNS-resolution probe is not achievable without a static client binary (initContainer or custom image). Keeping #40 open for that follow-up.

> Includes a second commit `chore(squad)` — team-state bookkeeping only, ignore for review.

## Manual follow-ups after merge (not GitOps)
- **#42:** prune is OFF → delete orphaned services: `kubectl -n pihole delete svc pihole-dns-udp pihole-dns-tcp`
- **#43:** klipper releases NTP on old node IPs — repoint any NTP client / DHCP option to `192.168.52.54`
- **#28:** cert-manager auto-provisions the `pihole-tls` certs via `letsencrypt-prod` (no action if cert-manager is healthy)
- **#27 gravity sync:** after a pihole pod is recreated from scratch, run the manual sync job (see the new runbook)

🤖 Prepared by Squad (Dallas, Lambert).