### PR TITLE
Tune MariaDB for low-memory Pi + subPath datadir (uptime deploy fix)

### DIFF
--- a/apps/uptime/kustomization.yml
+++ b/apps/uptime/kustomization.yml
@@ -15,6 +15,9 @@ configMapGenerator:
   - name: uptime-configmap
     envs:
       - .env
+  - name: uptime-mariadb-config
+    files:
+      - mariadb-tuning.cnf
 
 resources:
   - namespace.yml

--- a/apps/uptime/mariadb-statefulset.yml
+++ b/apps/uptime/mariadb-statefulset.yml
@@ -26,6 +26,9 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: uptime-mariadb-pvc
+        - name: config
+          configMap:
+            name: uptime-mariadb-config
       containers:
         - name: mariadb
           image: mariadb:11.4.12  # LTS; arm64/v8 confirmed on Docker Hub 2026-06-26
@@ -33,6 +36,11 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/mysql
+              subPath: data  # init into an empty subdir so the volume's lost+found does not block first-run init
+            - name: config
+              mountPath: /etc/mysql/conf.d/zz-pi-tuning.cnf
+              subPath: mariadb-tuning.cnf
+              readOnly: true
           env:
             - name: MARIADB_ROOT_PASSWORD
               valueFrom:
@@ -57,7 +65,7 @@ spec:
               protocol: TCP
           resources:
             requests:
-              memory: "256Mi"
+              memory: "384Mi"
               cpu: "100m"
             limits:
               memory: "1Gi"
@@ -74,7 +82,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 10
-            failureThreshold: 12  # up to 2 minutes for first start
+            failureThreshold: 30  # up to ~5 min for a cold first init on a Pi (image unpack + InnoDB init)
           readinessProbe:
             exec:
               command:

--- a/apps/uptime/mariadb-tuning.cnf
+++ b/apps/uptime/mariadb-tuning.cnf
@@ -1,0 +1,14 @@
+# MariaDB tuning for Raspberry Pi 4B (4GB RAM, USB-SSD via Longhorn).
+# Goal: keep the memory + I/O footprint small so a cold start / InnoDB init
+# does not drive the node into an I/O-wait storm (see the 2026-06-26 incident
+# where an untuned cold start pushed a worker to load 67 and NotReady).
+[mariadbd]
+innodb_buffer_pool_size        = 128M
+innodb_log_file_size           = 48M
+innodb_flush_method            = O_DIRECT
+innodb_flush_log_at_trx_commit = 2
+innodb_io_capacity             = 200
+innodb_io_capacity_max         = 400
+max_connections                = 50
+performance_schema             = OFF
+skip_name_resolve              = ON


### PR DESCRIPTION
Follow-up to the 2026-06-26 uptime deploy incident. With rpi003's fan replaced (thermal fixed), this makes the MariaDB cold-start safe on the 4GB Pis so it does not re-overload a node.

- **`mariadb-tuning.cnf`** (ConfigMap → `/etc/mysql/conf.d`): `innodb_buffer_pool_size=128M`, `innodb_log_file_size=48M`, `O_DIRECT`, `flush_log_at_trx_commit=2`, capped `innodb_io_capacity`, `performance_schema=OFF`, `max_connections=50` — minimal memory + I/O footprint.
- **`subPath: data`** on the datadir mount → MariaDB initializes into an empty subdir, so the ext4 volume's `lost+found` cannot trip first-run init (the likely `Unknown/unsupported storage engine: InnoDB` cause).
- **startupProbe** `failureThreshold` 12 → 30 (~5 min cold-init headroom).
- MariaDB memory request 256Mi → 384Mi.

`scripts/validate.sh` passes. Retry plan: pre-pull the image on workers, recreate a pristine PVC, deploy on the cooled cluster, watch node load.