### PR TITLE
fix(metallb): harden against node-overload to protect DNS VIP

### DIFF
--- a/platform/metallb/helm-values.yaml
+++ b/platform/metallb/helm-values.yaml
@@ -29,6 +29,9 @@ frrk8s:
 
 controller:
   logLevel: info
+  # Keep MetalLB admitted during node-overload incidents so DNS VIP assignment
+  # is not starved behind normal workloads.
+  priorityClassName: system-cluster-critical
   resources:
     requests:
       cpu: 25m
@@ -39,6 +42,9 @@ controller:
 
 speaker:
   logLevel: info
+  # Keep VIP advertisement running during node-overload incidents; the DNS VIP
+  # depends on speakers staying schedulable and healthy.
+  priorityClassName: system-cluster-critical
   # L2 mode: speaker uses ARP, not FRR/BGP.
   frr:
     enabled: false
@@ -59,7 +65,8 @@ speaker:
       memory: 64Mi
     limits:
       cpu: 200m
-      memory: 128Mi
+      # Speaker was OOM-killed at 128Mi during the DNS-VIP incident.
+      memory: 256Mi
 
 # Metrics wiring into kube-prometheus-stack can be enabled later once validated;
 # the ServiceMonitor CRD lives in the monitoring stack.


### PR DESCRIPTION
## Why

During today's uptime-kuma MariaDB rebuild, heavy I/O (large image pulls + InnoDB init) overloaded the 4 GB Pi workers. **MetalLB became collateral and took down the entire home-network DNS** — not Pi-hole, which stayed healthy throughout.

Failure chain:
- `metallb-controller` wedged `0/1` — the saturated node's kubelet was too I/O-busy to start its sandbox, so it couldn't assign pending LoadBalancer VIPs.
- `metallb-speaker` was **OOM-killed** (exit 137, 9 restarts) at its **128Mi** memory limit.
- The `dns-vip` **`192.168.52.53`** (MetalLB `IPAddressPool` -> `dnsdist` LB) and `ingress-vip` `.80` went pending/unannounced. The **UDM-Pro resolves through `.53`**, so the whole LAN lost DNS.

Recovered live by rescheduling the controller to a healthy node + uncordoning workers. This PR hardens MetalLB so a node overload can't repeat this.

## What

`platform/metallb/helm-values.yaml` (adopted MetalLB chart `0.15.2`):

- **`priorityClassName: system-cluster-critical`** on **both** `controller` and `speaker` — the scheduler/kubelet won't starve or evict them behind normal workloads under node pressure. Verified the key exists in chart 0.15.2 via `helm show values metallb/metallb --version 0.15.2`.
- **Speaker memory limit `128Mi` -> `256Mi`** (it OOM'd at 128Mi). Live verification: actual speaker usage is **20-51Mi**, and all 4 nodes have headroom for 256Mi. Controller limit left at 128Mi (it was scheduling-starved, not OOM'd — priorityClass addresses that).

Minimal, additive, well-commented (public teaching repo).

## Validation

- `scripts/validate.sh` passes (kustomize build + helm template + secret scan + prune/selfHeal guard; only pre-existing warnings: argocd chart-map, kubeconform not installed)
- Live-checked: `system-cluster-critical` (2000000000) + `system-node-critical` present; per-node memory headroom confirmed.

## Manual step after merge

This stack has **no auto-sync** — manually sync the `metallb` Application in ArgoCD (pass `ServerSideApply=true` if prompted). The speaker DaemonSet + controller Deployment roll with the new priorityClass + limit, one pod at a time; DNS stays up.

## Related

- Relates to **#44** (MetalLB speaker resilience) — addresses the core of it.
- Informs **#42** (remove legacy klipper DNS LB): during this outage, klipper node-IP DNS was the only DNS path still serving. Recommend **keeping klipper as a fallback** until MetalLB hardening is proven.

## Follow-up (separate PR — node-level resilience)

Live analysis surfaced node-OS hardening to help the Pis survive I/O storms (advisory, not in this PR):
- kubelet `--system-reserved`/`--kube-reserved` + eviction thresholds via Ansible
- `vm.dirty_ratio`/`vm.dirty_background_ratio` sysctls to tame write-back storms on slow SSD (live defaults 20/10)
- swap review (tiny 99Mi `/var/swap` live; consider documented zram tradeoffs)
