### PR TITLE
feat(gitops): promote meal-planner + localproxy to Gate-3 auto-sync

### DIFF
--- a/clusters/rpi/apps-appset.yml
+++ b/clusters/rpi/apps-appset.yml
@@ -40,12 +40,17 @@ spec:
           # `kube-system-metrics` Application (see platform-apps.yml wave 0).
           - path: apps/kube-system
             exclude: true
-          # shlink and uptime have been promoted to gate 3 (auto-sync). They
-          # are defined as explicit Applications below so syncPolicy.automated
-          # can be set per-app. See transition notes in those Applications.
+          # shlink, uptime, meal-planner, and localproxy have been promoted to
+          # gate 3 (auto-sync). They are defined as explicit Applications below
+          # so syncPolicy.automated can be set per-app. See transition notes in
+          # those Applications.
           - path: apps/shlink
             exclude: true
           - path: apps/uptime
+            exclude: true
+          - path: apps/meal-planner
+            exclude: true
+          - path: apps/localproxy
             exclude: true
   template:
     metadata:
@@ -84,23 +89,26 @@ spec:
 ##############################################################################
 # Gate-3 (auto-sync) explicit Applications
 #
-# shlink and uptime are excluded from the ApplicationSet generator above and
-# defined here as explicit Applications so syncPolicy.automated can be set
-# per-app (the shared template cannot carry automated because it applies to
-# ALL apps including stateful ones not ready for it).
+# shlink, uptime, meal-planner, and localproxy are excluded from the
+# ApplicationSet generator above and defined here as explicit Applications so
+# syncPolicy.automated can be set per-app (the shared template cannot carry
+# automated because it applies to ALL apps including stateful ones not ready for
+# it).
 #
 # Gate 3 only: automated: {} means auto-sync on drift. prune and selfHeal are
 # deliberately omitted — those are gate 5 and gate 4 respectively and require
 # a separate, observed promotion step.
 #
 # TRANSITION NOTE (for Brandon): when root is synced with this file, the
-# ApplicationSet controller will DELETE the appset-generated `shlink` and
-# `uptime` Applications (their cluster resources are NOT deleted because prune
-# was OFF on the template). These explicit Applications are then created by
-# root and auto-sync reconciles the running workloads. Recommended sync order:
+# ApplicationSet controller will DELETE the appset-generated `shlink`,
+# `uptime`, `meal-planner`, and `localproxy` Applications (their cluster
+# resources are NOT deleted because prune was OFF on the template). These
+# explicit Applications are then created by root and auto-sync reconciles the
+# running workloads. Recommended sync order:
 #   1. Sync `root` (picks up this file — creates these Applications and updates
 #      the ApplicationSet with the new exclusions simultaneously)
-#   2. Verify shlink and uptime Applications appear Synced / auto-syncing
+#   2. Verify shlink, uptime, meal-planner, and localproxy Applications appear
+#      Synced / auto-syncing
 #   There is no manual pre-step needed; ArgoCD handles the Application name
 #   hand-off because the appset deletes its copy and root creates the explicit
 #   copy in the same reconcile pass.
@@ -162,3 +170,73 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+---
+##############################################################################
+# Gate-3 stateless, HPA-backed promotions
+#
+# meal-planner and localproxy are stateless and HPA-backed, so auto-sync can
+# reconcile drift while prune and selfHeal remain deliberately off.
+##############################################################################
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: meal-planner
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/managed-by: argocd
+spec:
+  project: apps
+  source:
+    repoURL: https://github.com/brandonmartinez/raspberry-pi-kubernetes-cluster.git
+    targetRevision: main
+    path: apps/meal-planner
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: meal-planner
+  # Gate 3: auto-sync enabled. prune and selfHeal are NOT enabled (gates 5/4).
+  # HPA owns /spec/replicas — ignored so ArgoCD never reverts autoscaler decisions.
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
+  syncPolicy:
+    automated: {}
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: localproxy
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/managed-by: argocd
+spec:
+  project: apps
+  source:
+    repoURL: https://github.com/brandonmartinez/raspberry-pi-kubernetes-cluster.git
+    targetRevision: main
+    path: apps/localproxy
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: localproxy
+  # Gate 3: auto-sync enabled. prune and selfHeal are NOT enabled (gates 5/4).
+  # HPA owns /spec/replicas — ignored so ArgoCD never reverts autoscaler decisions.
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
+  syncPolicy:
+    automated: {}
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true


### PR DESCRIPTION
## Why

Promotes two more apps to Gate-3 auto-sync. Currently only `shlink` + `uptime` auto-sync; everything else is manual. `meal-planner` and `localproxy` are **stateless, HPA-backed, low blast radius** — strong candidates per `docs/gitops.md` promotion gates.

**Risk framing:** auto-sync with `prune` + `selfHeal` OFF (our standing convention) applies committed drift but never deletes or reverts resources. It cannot cause the 2026-06-26 data-loss incident — that was an ApplicationSet exclusion *without* `preserveResourcesOnDeletion` (since fixed), not auto-sync itself.

## What

`clusters/rpi/apps-appset.yml`:
- Exclude `apps/meal-planner` + `apps/localproxy` from the directory generator (same mechanism as shlink/uptime) so each can carry its own `syncPolicy.automated`.
- Add explicit Applications for both: `automated: {}` (Gate 3), `ServerSideApply` + `CreateNamespace` + `RespectIgnoreDifferences`, and `ignoreDifferences` on `/spec/replicas` (both have HPAs — `meal-planner-hpa` → `meal-planner`, `localproxy-hpa` → `localproxy-nginx-deployment`).
- `prune` and `selfHeal` stay **OFF** (gates 5/4 unchanged).
- Updated the gate-3 enumerating comments + transition note.
- **Also restores** `RespectIgnoreDifferences=true` on the existing `shlink` Application (dropped in an intermediate edit, caught in review) so sync never writes `/spec/replicas` against shlink's HPA.

## Validation

- `scripts/validate.sh` ✅ — kustomize build + helm template + secret scan + **prune/selfHeal guard all pass** (only `automated` added, no prune/selfHeal).
- Verified all 4 auto-sync apps are internally consistent: HPA apps (shlink, meal-planner, localproxy) carry both the replicas-ignore + RespectIgnoreDifferences; uptime (fixed replicas, no HPA) carries neither.

## Manual step after merge

Sync `root` so the appset exclusions + the new explicit Applications take effect together. ArgoCD hands off the Application name in one reconcile pass; **resources are NOT deleted** (prune is off). Then verify `meal-planner` + `localproxy` show Synced / auto-syncing.

## Not in this PR (left on manual deliberately)

DNS/NTP path (`pihole`, `dnsdist`, `unbound`, `chrony`) stays human-observed after the DNS outage; `nebulasync` (Degraded), `minecraft`/`portainer` (slow stateful), `keycloak` (placeholder). `changedetection` + `pikaraoke` are reasonable future candidates.
