### PR TITLE
fix(longhorn): set filesystem-trim retain=0 to stop longhorn-jobs sync drift

### DIFF
--- a/platform/longhorn/recurring-jobs.yml
+++ b/platform/longhorn/recurring-jobs.yml
@@ -48,8 +48,10 @@ spec:
 # (02:00) has completed but before the daily backup (08:00).
 # concurrency: 1 — serialise across volumes to avoid saturating the single
 # USB 3.0 bus shared by all data disks on a Pi 4B node.
-# retain: 2 — keep last two execution records (trim produces no backup artefacts
-# to prune; this just controls the job-status history).
+# retain: 0 — REQUIRED. Longhorn's controller forces retain=0 for filesystem-trim
+# tasks (trim produces no snapshot/backup artefacts to retain). Any other value
+# is reset to 0 by longhorn-manager, which causes the longhorn-jobs ArgoCD
+# Application to re-drift to OutOfSync immediately after every sync. Keep at 0.
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
@@ -63,5 +65,5 @@ spec:
   labels: {}
   name: filesystem-trim-weekly
   parameters: {}
-  retain: 2
+  retain: 0
   task: filesystem-trim


### PR DESCRIPTION
## Problem

`longhorn-jobs` reports **Synced right after a sync, then immediately flips to OutOfSync** — a classic controller-vs-ArgoCD fight, not an orphan resource.

## Root cause

Only `RecurringJob/filesystem-trim-weekly` drifts (the other two RecurringJobs stay Synced). Git commits it with `retain: 2`, but the live value is `retain: 0`, and `metadata.managedFields` shows **`longhorn-manager` owns `spec.retain`**:

- Longhorn's controller **forces `retain: 0` for `filesystem-trim` tasks** — a trim job produces no snapshot/backup artefacts to retain, so `retain` is meaningless for it.
- Loop: ArgoCD applies `retain: 2` → longhorn-manager resets it to `0` → ArgoCD sees `0 ≠ 2` → OutOfSync → repeat.

(`backup-default` retain 10 and `snapshot-default` retain 7 are unaffected — those tasks legitimately honour `retain`, which is why they stay Synced.)

## Fix

Set `retain: 0` in git to match the controller-enforced value, and corrected the manifest comment (the old one wrongly claimed `retain: 2` keeps execution-record history). One-field change; no behavior change to the actual trim schedule.

## Validation

- `scripts/validate.sh` passes (incl. the prune/selfHeal guard — longhorn stays protected; this only changes a `retain` value).

## Manual step after merge

Sync `longhorn-jobs` once — it should now go **Synced and stay Synced** (git `retain: 0` == the value longhorn-manager enforces).
