### PR TITLE
Sprint 4 — Retro Actions (#65 #71 #66 #62 #54 #68 #67 #23 #69 #70)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -168,6 +168,23 @@ Read `docs/provisioning.md`. Provisioning is `ansible/`.
   Never redefine these — always source `_shared/echo.sh`.
 - Scripts must be **non-interactive** and **idempotent** where possible.
 
+## Multi-agent / AI workflow (git safety)
+
+- When multiple AI agents/subagents work concurrently, **git-mutating operations**
+  (`checkout`, `switch`, `commit`, `branch`, `stash`, `reset`, `rebase`,
+  `cherry-pick`) MUST NOT be run by more than one actor in the same working tree.
+- Use one of two safe patterns: **serialize** git-mutating work (one actor at a
+  time), or give each agent an **isolated git worktree** (`git worktree add`).
+- The **coordinator owns all commits**. Specialist agents edit files only and
+  receive explicit "do NOT run git" instructions unless they have their own
+  isolated worktree.
+- Agents working in a shared tree must stick to **disjoint file paths** to avoid
+  edit conflicts.
+- Before committing, the coordinator verifies the intended branch and HEAD are
+  correct, guarding against a moved HEAD.
+- Rationale: HEAD moved mid-commit once, corrupting local `main` and requiring
+  reflog recovery.
+
 ## Validation
 
 `scripts/validate.sh` is local CI (also run by a GitHub Action). It runs

--- a/ansible/roles/base/defaults/main.yml
+++ b/ansible/roles/base/defaults/main.yml
@@ -32,3 +32,20 @@ base_cgroup_options:
   - cgroup_enable=cpuset
   - cgroup_enable=memory
   - cgroup_memory=1
+# Node-resilience tuning from the DNS-outage/overload incident. These are only
+# applied when base_apply is true, so adopt.yml --check --diff remains read-only.
+base_manage_writeback_sysctls: true
+base_writeback_sysctls:
+  # Raspberry Pi USB SSDs stall badly when Linux lets too much dirty memory
+  # accumulate. Keep writeback smaller than the default 20/10 percent.
+  - name: vm.dirty_ratio
+    value: "10"
+  - name: vm.dirty_background_ratio
+    value: "5"
+# Disable the vestigial Raspberry Pi OS /var/swap instead of adding zram. The
+# cluster relies on kubelet reservations/evictions and Longhorn-backed storage;
+# small slow swap masks memory pressure and can amplify I/O stalls during heavy
+# rollouts.
+base_disable_legacy_var_swap: true
+base_legacy_swap_path: /var/swap
+base_legacy_swap_service: dphys-swapfile.service

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -107,6 +107,65 @@
     - base_apply | bool
     - base_remove_avahi | bool
 
+- name: Inspect active swap devices
+  ansible.builtin.command: swapon --show=NAME --noheadings
+  register: base_active_swap
+  changed_when: false
+  failed_when: false
+  check_mode: false
+
+- name: Stat legacy Raspberry Pi OS swap file
+  ansible.builtin.stat:
+    path: "{{ base_legacy_swap_path }}"
+  register: base_legacy_swap_stat
+  changed_when: false
+  check_mode: false
+
+- name: Report legacy swap decision
+  ansible.builtin.debug:
+    msg:
+      - "legacy swap path={{ base_legacy_swap_path }} exists={{ base_legacy_swap_stat.stat.exists }}"
+      - "active swap devices={{ base_active_swap.stdout_lines | default([]) }}"
+      - "disable legacy /var/swap apply={{ (base_apply | bool) and (base_disable_legacy_var_swap | bool) }}"
+      - "tradeoff: no slow USB-backed swap; kubelet reservations/evictions surface memory pressure sooner."
+
+- name: Stop active legacy swap file
+  ansible.builtin.command: "swapoff {{ base_legacy_swap_path | quote }}"
+  when:
+    - base_apply | bool
+    - base_disable_legacy_var_swap | bool
+    - base_legacy_swap_path in (base_active_swap.stdout_lines | default([]))
+
+- name: Disable dphys-swapfile service when present
+  ansible.builtin.systemd:
+    name: "{{ base_legacy_swap_service }}"
+    enabled: false
+    state: stopped
+  failed_when: false
+  when:
+    - base_apply | bool
+    - base_disable_legacy_var_swap | bool
+
+- name: Remove legacy Raspberry Pi OS swap file
+  ansible.builtin.file:
+    path: "{{ base_legacy_swap_path }}"
+    state: absent
+  when:
+    - base_apply | bool
+    - base_disable_legacy_var_swap | bool
+
+- name: Tune dirty writeback thresholds for USB SSD nodes
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    sysctl_file: /etc/sysctl.d/90-homelab-writeback.conf
+    state: present
+    reload: true
+  loop: "{{ base_writeback_sysctls }}"
+  when:
+    - base_apply | bool
+    - base_manage_writeback_sysctls | bool
+
 - name: Stat Bookworm boot cmdline path (/boot/firmware/cmdline.txt)
   ansible.builtin.stat:
     path: /boot/firmware/cmdline.txt

--- a/ansible/roles/k3s_agent/defaults/main.yml
+++ b/ansible/roles/k3s_agent/defaults/main.yml
@@ -6,5 +6,18 @@ k3s_server_url: "https://192.168.52.110:6443"
 k3s_token: ""
 k3s_common_kubelet_args:
   - node-ip=0.0.0.0
+k3s_config_dir: /etc/rancher/k3s
+k3s_config_file: "{{ k3s_config_dir }}/config.yaml"
+# Worker node-resilience tuning from the DNS-outage/overload incident. Gated by
+# k3s_apply in adopt.yml; roll agents one at a time while watching DNS/MetalLB.
+k3s_node_resilience_kubelet_args:
+  # rpi002/rpi003/rpi004 have 4GiB RAM; keep headroom for kubelet, containerd,
+  # Longhorn, MetalLB speaker, and kernel writeback under heavy image pulls.
+  - system-reserved=cpu=150m,memory=384Mi
+  - kube-reserved=cpu=200m,memory=512Mi
+  - eviction-hard=memory.available<384Mi,nodefs.available<10%,imagefs.available<15%
+  - eviction-soft=memory.available<640Mi,nodefs.available<15%,imagefs.available<20%
+  - eviction-soft-grace-period=memory.available=2m,nodefs.available=5m,imagefs.available=5m
+  - eviction-max-pod-grace-period=60
 k3s_common_kube_proxy_args:
   - metrics-bind-address=0.0.0.0

--- a/ansible/roles/k3s_agent/handlers/main.yml
+++ b/ansible/roles/k3s_agent/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart k3s agent
+  ansible.builtin.systemd:
+    name: k3s-agent
+    state: restarted
+  when: k3s_apply | bool

--- a/ansible/roles/k3s_agent/tasks/main.yml
+++ b/ansible/roles/k3s_agent/tasks/main.yml
@@ -10,6 +10,36 @@
       k3s agent service exists={{ k3s_agent_service.stat.exists }};
       join will {{ 'be skipped' if k3s_agent_service.stat.exists or not (k3s_apply | bool) else 'run' }}.
 
+- name: Ensure k3s agent config directory exists
+  ansible.builtin.file:
+    path: "{{ k3s_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: k3s_apply | bool
+
+- name: Manage k3s agent config with kubelet resilience args
+  ansible.builtin.copy:
+    dest: "{{ k3s_config_file }}"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # Managed by Ansible. Node-resilience settings were added after the
+      # DNS-outage/overload incident; apply by rolling one worker at a time while
+      # watching DNS, MetalLB, Longhorn, and node pressure.
+      kubelet-arg:
+      {% for arg in (k3s_common_kubelet_args + k3s_node_resilience_kubelet_args) %}
+        - {{ arg | to_json }}
+      {% endfor %}
+      kube-proxy-arg:
+      {% for arg in k3s_common_kube_proxy_args %}
+        - {{ arg | to_json }}
+      {% endfor %}
+  notify: restart k3s agent
+  when: k3s_apply | bool
+
 - name: Require k3s token for fresh agent joins
   ansible.builtin.fail:
     msg: "Set k3s_token via Ansible Vault or -e before provisioning a fresh agent."
@@ -24,8 +54,7 @@
     INSTALL_K3S_CHANNEL={{ k3s_channel | quote }}
     K3S_URL={{ k3s_server_url | quote }}
     K3S_TOKEN={{ k3s_token | quote }} sh -s -
-    {% for arg in k3s_common_kubelet_args %} --kubelet-arg={{ arg | quote }}{% endfor %}
-    {% for arg in k3s_common_kube_proxy_args %} --kube-proxy-arg {{ arg | quote }}{% endfor %}
+    --config {{ k3s_config_file | quote }}
   args:
     creates: "{{ k3s_agent_service_file }}"
   no_log: true

--- a/ansible/roles/k3s_server/defaults/main.yml
+++ b/ansible/roles/k3s_server/defaults/main.yml
@@ -5,6 +5,19 @@ k3s_service_file: /etc/systemd/system/k3s.service
 k3s_write_kubeconfig_mode: "644"
 k3s_common_kubelet_args:
   - node-ip=0.0.0.0
+k3s_config_dir: /etc/rancher/k3s
+k3s_config_file: "{{ k3s_config_dir }}/config.yaml"
+# Control-plane node-resilience tuning from the DNS-outage/overload incident.
+# Gated by k3s_apply in adopt.yml; roll this one node at a time after cordon,
+# drain, and DNS/MetalLB observation.
+k3s_node_resilience_kubelet_args:
+  # rpi001 has 8GiB RAM and also hosts control-plane components.
+  - system-reserved=cpu=250m,memory=512Mi
+  - kube-reserved=cpu=250m,memory=768Mi
+  - eviction-hard=memory.available<512Mi,nodefs.available<10%,imagefs.available<15%
+  - eviction-soft=memory.available<768Mi,nodefs.available<15%,imagefs.available<20%
+  - eviction-soft-grace-period=memory.available=2m,nodefs.available=5m,imagefs.available=5m
+  - eviction-max-pod-grace-period=60
 k3s_common_kube_proxy_args:
   - metrics-bind-address=0.0.0.0
 k3s_server_controller_manager_args:

--- a/ansible/roles/k3s_server/handlers/main.yml
+++ b/ansible/roles/k3s_server/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart k3s server
+  ansible.builtin.systemd:
+    name: k3s
+    state: restarted
+  when: k3s_apply | bool

--- a/ansible/roles/k3s_server/tasks/main.yml
+++ b/ansible/roles/k3s_server/tasks/main.yml
@@ -10,16 +10,51 @@
       k3s server service exists={{ k3s_server_service.stat.exists }};
       install will {{ 'be skipped' if k3s_server_service.stat.exists or not (k3s_apply | bool) else 'run' }}.
 
-- name: Install k3s server with legacy-compatible flags
+- name: Ensure k3s server config directory exists
+  ansible.builtin.file:
+    path: "{{ k3s_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: k3s_apply | bool
+
+- name: Manage k3s server config with kubelet resilience args
+  ansible.builtin.copy:
+    dest: "{{ k3s_config_file }}"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # Managed by Ansible. Node-resilience settings were added after the
+      # DNS-outage/overload incident; apply by rolling one node at a time while
+      # watching DNS, MetalLB, Longhorn, and node pressure.
+      write-kubeconfig-mode: "{{ k3s_write_kubeconfig_mode }}"
+      kubelet-arg:
+      {% for arg in (k3s_common_kubelet_args + k3s_node_resilience_kubelet_args) %}
+        - {{ arg | to_json }}
+      {% endfor %}
+      kube-proxy-arg:
+      {% for arg in k3s_common_kube_proxy_args %}
+        - {{ arg | to_json }}
+      {% endfor %}
+      kube-controller-manager-arg:
+      {% for arg in k3s_server_controller_manager_args %}
+        - {{ arg | to_json }}
+      {% endfor %}
+      kube-scheduler-arg:
+      {% for arg in k3s_server_scheduler_args %}
+        - {{ arg | to_json }}
+      {% endfor %}
+      prefer-bundled-bin: {{ k3s_prefer_bundled_bin | bool | ternary('true', 'false') }}
+  notify: restart k3s server
+  when: k3s_apply | bool
+
+- name: Install k3s server with managed config
   ansible.builtin.shell: >-
     curl -sfL https://get.k3s.io |
     INSTALL_K3S_CHANNEL={{ k3s_channel | quote }} sh -s -
-    --write-kubeconfig-mode {{ k3s_write_kubeconfig_mode | quote }}
-    {% for arg in k3s_common_kubelet_args %} --kubelet-arg={{ arg | quote }}{% endfor %}
-    {% for arg in k3s_server_controller_manager_args %} --kube-controller-manager-arg {{ arg | quote }}{% endfor %}
-    {% for arg in k3s_common_kube_proxy_args %} --kube-proxy-arg {{ arg | quote }}{% endfor %}
-    {% for arg in k3s_server_scheduler_args %} --kube-scheduler-arg {{ arg | quote }}{% endfor %}
-    {% if k3s_prefer_bundled_bin | bool %} --prefer-bundled-bin{% endif %}
+    --config {{ k3s_config_file | quote }}
   args:
     creates: "{{ k3s_service_file }}"
   when:

--- a/docs/dns-architecture.md
+++ b/docs/dns-architecture.md
@@ -1,0 +1,163 @@
+# DNS architecture
+
+This cluster intentionally teaches the full DNS path instead of hiding it behind
+one appliance. The LAN resolver is a Kubernetes Service, but it is still operated
+as production infrastructure: if DNS is down, almost everything else feels down.
+
+## Request path
+
+```text
+LAN clients
+  -> UDM-Pro DHCP advertises 192.168.52.53 as DNS
+  -> MetalLB Layer-2 VIP 192.168.52.53 (dns-vip)
+  -> dnsdist LoadBalancer Service in apps/dnsdist
+  -> Pi-hole DNS Service
+  -> unbound / upstream resolvers
+```
+
+`192.168.52.53` is the single DNS address for the home LAN. The UDM-Pro hands it
+out by DHCP, and clients send both UDP and TCP port 53 traffic there. MetalLB
+announces that address on Layer 2 and sends traffic to the `dnsdist` LoadBalancer
+Service.
+
+`dnsdist` is the front door. It runs multiple replicas, uses
+`externalTrafficPolicy: Local`, and is spread across nodes so MetalLB only
+announces the VIP from a node with a ready local dnsdist endpoint. dnsdist then
+forwards normal traffic to the Pi-hole cluster Service. If every Pi-hole backend
+is unhealthy, dnsdist has a last-ditch public resolver pool so the LAN can still
+resolve names while Pi-hole is repaired; normal operation should be 100% Pi-hole.
+
+Pi-hole remains the policy layer behind dnsdist: ad blocking, local DNS behavior,
+and the handoff to unbound/upstream resolvers. Pi-hole is no longer the public
+LoadBalancer entrypoint for the LAN.
+
+## MetalLB dependency
+
+The DNS VIP depends on MetalLB being healthy:
+
+- the MetalLB controller allocates the requested VIP from the `dns-vip`
+  `IPAddressPool`;
+- the MetalLB speakers announce the VIP with Layer-2 ARP;
+- the `dnsdist` Service explicitly requests `192.168.52.53` and
+  `loadBalancerClass: metallb.io/layer2`.
+
+This is a hard dependency. During the DNS outage, the important lesson was that a
+healthy Pi-hole pod is not enough if MetalLB cannot assign or announce `.53`.
+The mitigation is to keep MetalLB admitted and alive under node pressure:
+`platform/metallb/helm-values.yaml` gives the controller and speaker
+`system-cluster-critical` priority, and the speaker memory limit was raised after
+an OOM-kill incident. Node-resilience work complements this by reducing the odds
+that the VIP leader or all dnsdist endpoints disappear at the same time.
+
+## Retired klipper fallback
+
+The old node-IP klipper Services `pihole-dns-tcp` and `pihole-dns-udp` have been
+retired. They were useful during migration, but they created two DNS paths with
+different failure modes and made drift cleanup harder. The steady-state design is
+now one path:
+
+```text
+192.168.52.53 -> dnsdist -> Pi-hole -> unbound/upstream
+```
+
+Do not add a permanent public secondary resolver in DHCP. Client resolver
+failover is OS-dependent and timeout-based, and a public secondary silently
+bypasses split-horizon names and Pi-hole filtering whenever a client races it.
+Use the temporary DHCP fallback in [runbooks/break-glass.md](runbooks/break-glass.md)
+only during a DNS incident.
+
+## Single point of failure analysis
+
+The design has one LAN-facing VIP by choice. A second DNS VIP inside the same
+cluster would share the same dnsdist, Pi-hole, unbound, kube-proxy, and MetalLB
+failure domains while making client behavior less predictable. The useful HA
+boundary is not multiple client-facing addresses; it is making the one address
+move quickly to a healthy node.
+
+Covered failures:
+
+- one node dies: MetalLB can move `.53` to another node with a ready dnsdist pod;
+- one dnsdist pod dies: endpoints and Local traffic policy keep the VIP on nodes
+  with ready pods;
+- one Pi-hole pod dies: kube-proxy sends dnsdist to remaining Pi-hole endpoints;
+- all Pi-hole pods die: dnsdist can temporarily use its backup resolver pool.
+
+Still serious failures:
+
+- MetalLB controller or speakers unhealthy;
+- no ready dnsdist endpoints;
+- kube-proxy or CNI failure on the VIP leader;
+- Pi-hole and backup resolver paths both unavailable;
+- router DHCP still pointing clients somewhere stale.
+
+## If `192.168.52.53` stops resolving
+
+Work from the outside inward.
+
+### 1. Confirm the client path
+
+```sh
+nslookup themartinez.cloud 192.168.52.53
+dig @192.168.52.53 themartinez.cloud
+```
+
+If clients need immediate internet DNS while the cluster is repaired, use the
+break-glass DHCP fallback in [runbooks/break-glass.md](runbooks/break-glass.md).
+Revert DHCP to `192.168.52.53` after recovery.
+
+### 2. Check VIP assignment and MetalLB
+
+```sh
+kubectl -n dnsdist get svc dnsdist -o wide
+kubectl -n metallb-system get pods -o wide
+kubectl -n metallb-system logs deploy/metallb-controller --tail=100
+kubectl -n metallb-system logs ds/metallb-speaker --tail=100
+kubectl -n metallb-system get ipaddresspool,l2advertisement
+```
+
+Look for `.53` on the Service, ready controller and speaker pods, speaker
+restarts, and allocation or announcement errors. The real recovery path included
+restoring MetalLB health so the speakers could announce the VIP again.
+
+### 3. Check dnsdist
+
+```sh
+kubectl -n dnsdist get pods -o wide
+kubectl -n dnsdist get endpoints dnsdist -o wide
+kubectl -n dnsdist logs deploy/dnsdist --tail=100
+```
+
+There should be ready dnsdist pods on more than one node. Because the Service
+uses `externalTrafficPolicy: Local`, a node without a ready local dnsdist pod
+should not be the place MetalLB sends the VIP.
+
+### 4. Check Pi-hole behind dnsdist
+
+```sh
+kubectl -n pihole get pods,svc,endpoints -o wide
+kubectl -n pihole logs statefulset/pihole --tail=100
+```
+
+If dnsdist is reachable but queries fail or fall back to public resolvers, verify
+that Pi-hole endpoints exist and that Pi-hole can reach unbound/upstream
+resolvers.
+
+### 5. Verify recovery
+
+```sh
+nslookup themartinez.cloud 192.168.52.53
+nslookup bmtn.us 192.168.52.53
+kubectl -n dnsdist get svc dnsdist -o wide
+kubectl -n metallb-system get pods -o wide
+```
+
+Once `.53` resolves reliably, remove any temporary DHCP fallback and confirm a
+client receives `192.168.52.53` again on lease renewal.
+
+## Source files
+
+- `apps/dnsdist/` defines the dnsdist Deployment, config, PDB, and VIP Service.
+- `apps/pihole/` defines the Pi-hole workload behind dnsdist.
+- `platform/metallb/` defines MetalLB values, the `dns-vip` pool, and Layer-2
+  advertisement.
+- `components/cluster-config/` fans the DNS VIP value into consumers that opt in.

--- a/docs/runbooks/argocd-outofsync.md
+++ b/docs/runbooks/argocd-outofsync.md
@@ -1,0 +1,182 @@
+# Runbook: ArgoCD OutOfSync troubleshooting
+
+Use this when an Application stays `OutOfSync` after the desired Git change has
+landed. Start by identifying the drift class before changing live resources.
+
+## Decision tree
+
+- **Sync succeeds, then the app immediately drifts again** -> suspect a
+  controller-enforced field. Check `managedFields` to see which controller owns
+  the field.
+- **`kubectl diff` is clean, but ArgoCD still reports `OutOfSync`** -> suspect
+  immutable-field drift. Confirm the live immutable field differs from Git.
+- **A resource exists live but is not rendered from Git** -> suspect an orphan
+  left behind while prune is off. Confirm it is absent from `kustomize build`,
+  then delete it by hand.
+
+## Orphan resources under prune-off
+
+### Symptom
+
+The Application remains `OutOfSync` forever, and another sync does not remove the
+extra object. ArgoCD shows a live resource that no longer exists in Git.
+
+Examples from this cycle:
+
+- uptime's old sqlite backup CronJob after the workload moved away from that
+  backup path.
+- Pi-hole's legacy klipper `pihole-dns-tcp` and `pihole-dns-udp` LoadBalancer
+  Services after DNS moved to the dnsdist MetalLB VIP.
+
+### Diagnose
+
+```sh
+kubectl -n argocd get app <app> -o jsonpath='{.status.sync.status}{"\n"}'
+kubectl -n argocd get app <app> -o jsonpath='{range .status.resources[*]}{.kind}{"\t"}{.namespace}{"\t"}{.name}{"\t"}{.status}{"\n"}{end}'
+
+# Render Git and confirm the resource name is not present.
+kustomize build apps/<app> | grep '<resource-name>' || true
+
+# Confirm the object still exists live.
+kubectl -n <namespace> get <kind> <resource-name>
+```
+
+Useful concrete checks:
+
+```sh
+kustomize build apps/uptime | grep sqlite-backup || true
+kubectl -n uptime get cronjob
+
+kustomize build apps/pihole | grep -E 'pihole-dns-(tcp|udp)' || true
+kubectl -n pihole get svc pihole-dns-tcp pihole-dns-udp
+```
+
+### Root cause
+
+Prune is deliberately off for most Applications. That is safe for production,
+but it also means removing an object from Git does not remove the live object.
+Manual sync only applies rendered objects; it does not delete extras.
+
+### Fix
+
+1. Confirm the object is no longer rendered by `kustomize build`.
+2. Confirm the object is not required by any current client or migration path.
+3. Delete the live orphan explicitly:
+
+```sh
+kubectl -n <namespace> delete <kind> <resource-name>
+```
+
+Then re-check the Application resource list. Do not enable prune just to clean up
+one known orphan on a stateful or protected app.
+
+## Immutable-field drift
+
+### Symptom
+
+ArgoCD stays `OutOfSync`, but a normal apply or diff may not show a pending
+change. Sync cannot converge because Kubernetes will never mutate the field in
+place.
+
+Example from this cycle: moving chrony's LoadBalancer from klipper to MetalLB at
+`192.168.52.54` required adding `spec.loadBalancerClass: metallb.io/layer2`.
+`Service.spec.loadBalancerClass` is immutable after the Service is created.
+
+### Diagnose
+
+```sh
+# Render the desired Service from Git.
+kustomize build apps/chrony | grep -A40 '^kind: Service'
+
+# Check the live immutable field.
+kubectl -n chrony get svc chrony-ntp-udp -o jsonpath='{.spec.loadBalancerClass}{"\n"}'
+kubectl -n chrony get svc chrony-ntp-udp -o jsonpath='{.spec.loadBalancerIP}{"\n"}'
+kubectl -n chrony get svc chrony-ntp-udp -o jsonpath='{.metadata.annotations.metallb\.universe\.tf/loadBalancerIPs}{"\n"}'
+
+# Server-side diff can appear clean even though ArgoCD still cannot make the
+# immutable field match on the existing object.
+kustomize build apps/chrony | kubectl diff --server-side -f -
+```
+
+For a generic Service, inspect the immutable field directly:
+
+```sh
+kubectl -n <namespace> get svc <service> -o jsonpath='{.spec.loadBalancerClass}{"\n"}'
+```
+
+### Root cause
+
+Kubernetes rejects updates to immutable fields. ArgoCD can keep retrying, but the
+existing object cannot be transformed from the old class to the new class. The
+live object must be replaced.
+
+### Fix
+
+Plan a brief interruption for the Service address, then delete and recreate the
+resource from Git:
+
+```sh
+kubectl -n <namespace> delete svc <service>
+kustomize build apps/<app> | kubectl apply --server-side -f -
+```
+
+After recreation, verify the immutable field and the LoadBalancer address:
+
+```sh
+kubectl -n <namespace> get svc <service> -o wide
+kubectl -n <namespace> get svc <service> -o jsonpath='{.spec.loadBalancerClass}{"\n"}'
+```
+
+Do not delete StatefulSets, PVCs, or selectors to silence a diff. This pattern is
+for resources whose immutable field is intentionally changing and whose
+interruption has been accepted.
+
+## Controller-enforced fields
+
+### Symptom
+
+ArgoCD syncs successfully, then the app immediately returns to `OutOfSync`. The
+same field keeps changing back after each sync.
+
+Example from this cycle: Longhorn forces `retain: 0` on `filesystem-trim`
+RecurringJobs. Git previously asked for a different value, so ArgoCD and the
+Longhorn controller fought over the same field.
+
+### Diagnose
+
+```sh
+# Compare desired and live values.
+kustomize build platform/longhorn | grep -A30 'filesystem-trim'
+kubectl -n longhorn-system get recurringjob filesystem-trim-weekly -o yaml
+
+# Identify which manager last wrote the field.
+kubectl -n longhorn-system get recurringjob filesystem-trim-weekly -o jsonpath='{range .metadata.managedFields[*]}{.manager}{"\t"}{.operation}{"\t"}{.time}{"\n"}{end}'
+
+# If needed, inspect managedFields with jq to find the manager that owns spec fields.
+kubectl -n longhorn-system get recurringjob filesystem-trim-weekly -o json \
+  | jq '.metadata.managedFields[] | {manager, operation, fieldsV1}'
+```
+
+If the live value changes back shortly after a sync and the controller appears in
+`managedFields`, treat the controller as the source of truth unless the
+controller documentation says otherwise.
+
+### Root cause
+
+Some controllers normalize or enforce parts of their custom resources. ArgoCD
+can apply Git, but the controller reconciles the field back to the value it
+requires.
+
+### Fix
+
+Prefer making Git match the controller-enforced value:
+
+```yaml
+spec:
+  task: filesystem-trim
+  retain: 0
+```
+
+Use `ignoreDifferences` only when the controller-owned field is noisy and not
+meaningful to GitOps intent. Do not hide fields that represent real desired
+state without documenting why the controller must own them.

--- a/docs/runbooks/backup-verification.md
+++ b/docs/runbooks/backup-verification.md
@@ -1,0 +1,85 @@
+# Runbook: backup verification
+
+Use this before any operation that touches or could affect persisted data: PVCs,
+StatefulSets, databases, Longhorn volumes, or anything with a reclaim consequence.
+The uptime incident proved that an ApplicationSet ownership change without the
+right safety flag can delete an app and its PVC. A hoped-for recovery path is not
+a backup.
+
+## Hard gate
+
+Before ANY operation that touches or could affect persisted data — PVCs,
+StatefulSets, databases, Longhorn volumes, anything with a reclaim consequence —
+you MUST, in order:
+
+1. Verify backups are configured for the affected data.
+2. Verify at least one backup has actually completed.
+3. Before a data-risking change, re-verify a fresh/current backup exists first.
+
+No verified, current backup means stop. Trigger a backup, confirm it completed,
+then proceed.
+
+## Helper
+
+Run the read-only helper from a workstation with the normal cluster `kubectl`
+context:
+
+```sh
+# Check every PVC in a namespace.
+scripts/verify-backup.sh <namespace>
+
+# Check one PVC.
+scripts/verify-backup.sh <namespace> <pvc>
+```
+
+The helper checks each target PVC by resolving the bound PV and storage class.
+It fails loudly for non-Longhorn storage, then for Longhorn volumes confirms:
+
+- the volume has a `recurring-job-group.longhorn.io/<group>: enabled` label;
+- that group is used by a Longhorn `RecurringJob` with `task: backup`;
+- at least one backup has completed, using the job `executionCount` and/or the
+  volume `lastBackup` status.
+
+## Longhorn model
+
+Longhorn is the backup system for durable Kubernetes volumes in this cluster.
+The committed recurring jobs are:
+
+- `backup-default`: daily at 08:00 UTC, retain 10, group `default`;
+- `snapshot-default`: daily at 02:00 UTC, retain 7, group `default`.
+
+A PVC is covered only when its Longhorn volume is labeled into a backup group,
+for example:
+
+```yaml
+metadata:
+  labels:
+    recurring-job-group.longhorn.io/default: enabled
+spec:
+  storageClassName: longhorn
+```
+
+Snapshots are useful rollback points, but the data-safety gate requires backups
+that leave the cluster through Longhorn's configured backup target.
+
+## What is not covered
+
+- `local-path` PVCs, especially with `Delete` reclaim, are not covered by
+  Longhorn backups. Treat them as fragile and migrate important state to
+  Longhorn before risky work.
+- Pushed Kubernetes Secrets are not Longhorn data. They persist in etcd and are
+  recreated from 1Password with `scripts/sync-secrets.sh`, so verify the
+  1Password source and workstation access instead.
+- Files outside Kubernetes volumes, router config, and workstation-only data need
+  their own backup evidence.
+
+## If no current backup exists
+
+1. Stop the data-risking change.
+2. In Longhorn, trigger an on-demand backup for the affected volume, or wait for
+   the appropriate `backup-default` run if the maintenance window allows it.
+3. Watch Longhorn until the backup is complete and healthy.
+4. Re-run `scripts/verify-backup.sh <namespace> [pvc]` and confirm it passes with
+   a current `lastBackup` or completed backup execution.
+5. Continue only after the backup evidence is recorded in the change notes or PR
+   description.

--- a/docs/runbooks/credential-rotation.md
+++ b/docs/runbooks/credential-rotation.md
@@ -1,0 +1,92 @@
+# Runbook: credential rotation
+
+Use this when a credential may have been exposed in git history or another public place. This runbook covers the old Uptime Kuma UI credential and the old Scrypted UI credential. Brandon performs the actual rotation because it requires 1Password and live service access.
+
+Assume any value that reached a public repo was already harvested. Rotation is the real fix. Git-history scrubbing is follow-up hygiene that may reduce future accidental discovery, but it does not make the old value safe again.
+
+## Scope and safety
+
+- Do not paste real credential values into tickets, commits, chat, or shell history.
+- Use placeholders such as `<old-uptime-ui-credential>`, `<new-uptime-ui-credential>`, and `<new-scrypted-ui-credential>` in notes.
+- Keep the cluster pull-free for secrets. Secrets are pushed from the 1Password `homelab` vault with `scripts/sync-secrets.sh`.
+- Do not use External Secrets Operator for this repo.
+
+## Rotate Uptime Kuma
+
+1. Open the 1Password `homelab` vault item that stores the Uptime Kuma UI credential.
+2. Generate a new value in 1Password and save it in the correct field. Record only `field` → `<new-uptime-ui-credential>` in notes.
+3. Sign in to Uptime Kuma with the current credential and rotate the UI credential inside the service.
+4. If Uptime Kuma reads any value from a pushed Kubernetes Secret, re-push only that target:
+   ```sh
+   scripts/sync-secrets.sh uptime
+   ```
+5. Verify the old UI credential no longer works and the new value from 1Password does work.
+6. Verify Uptime Kuma monitors are still running and alert delivery still works.
+
+## Rotate Scrypted
+
+1. Open the 1Password `homelab` vault item that stores the Scrypted UI credential.
+2. Generate a new value in 1Password and save it in the correct field. Record only `field` → `<new-scrypted-ui-credential>` in notes.
+3. Sign in to Scrypted with the current credential and rotate the UI credential inside the service.
+4. If Scrypted is later moved to Kubernetes and reads from a pushed Secret, re-push that service target with `scripts/sync-secrets.sh <target>`.
+5. Verify the old UI credential no longer works and the new value from 1Password does work.
+6. Verify cameras, plugins, and automations still connect after the change.
+
+## Re-push and reconcile pushed Secrets
+
+After any namespace recreation, app migration, or Secret-consuming service change:
+
+```sh
+scripts/sync-secrets.sh --verify <target>
+scripts/sync-secrets.sh --reconcile <target>
+```
+
+Use `--verify` first when you only want a read-only presence check. Use `--reconcile` when the Secret is missing and should be pushed from 1Password.
+
+For shared PostgreSQL clients, check the fan-out target:
+
+```sh
+scripts/sync-secrets.sh --verify postgres-app
+scripts/sync-secrets.sh --reconcile postgres-app
+```
+
+## Decide whether to scrub git history
+
+Rotate first, then decide whether a history scrub is worth the coordination cost.
+
+Reasons to scrub:
+
+- Reduce casual discovery of the old values in the public repo history.
+- Lower the chance that future clones, mirrors, or searches continue to surface the old values.
+- Demonstrate cleanup even though the exposed values are no longer valid.
+
+Risks and impact:
+
+- A scrub rewrites public git history and requires a force-push.
+- Existing forks, clones, open branches, and pull requests will diverge.
+- Contributors must coordinate fresh clones or hard resets after the rewrite.
+- Tags and release references may need to be recreated or documented.
+- Any cached copies, forks, package indexes, or search-engine snapshots can still retain the old values.
+
+Common tools:
+
+- `git filter-repo` for precise path, blob, or text replacement rewrites.
+- BFG Repo-Cleaner for simpler large-object or literal text cleanup.
+
+Decision framing:
+
+1. Confirm both exposed UI credentials have been rotated in 1Password and in the services.
+2. Confirm the old values fail against the live services.
+3. List affected refs, forks, and collaborators that would need coordination.
+4. If the coordination cost is acceptable, schedule a maintenance window for the rewrite and force-push.
+5. If the cost is not acceptable, document that rotation is complete and the remaining public history is accepted hygiene debt.
+
+## Verification checklist
+
+- Uptime Kuma accepts only `<new-uptime-ui-credential>`.
+- Scrypted accepts only `<new-scrypted-ui-credential>`.
+- The old Uptime Kuma and Scrypted values fail.
+- The relevant 1Password `homelab` items contain the new values.
+- `scripts/sync-secrets.sh --verify <target>` reports all expected pushed Secrets present for any Kubernetes-backed target.
+- Service health checks, monitors, cameras, and automations remain healthy.
+- If a history scrub is chosen, all collaborators have acknowledged the force-push plan before it happens.

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -33,6 +33,51 @@ This order rebuilds from significant cluster loss while preserving DNS and data 
 13. Restore/migrate Pi-hole last, following [pihole-migration.md](pihole-migration.md).
 14. Add ArgoCD self-management last.
 
+## ArgoCD cascade-delete safety
+
+An ApplicationSet generator change can become a data-loss event if it deletes the
+child `Application` and that Application does not preserve its resources. The
+incident pattern is:
+
+1. Remove an app from the `apps/*` generator, add an exclusion, or otherwise
+   transfer ownership to an explicit ArgoCD `Application`.
+2. The ApplicationSet controller deletes the generated `Application`.
+3. Without `spec.syncPolicy.preserveResourcesOnDeletion: true`, ArgoCD
+   cascade-deletes the application's managed resources, including its Namespace
+   and PVCs.
+4. If a PVC uses `local-path` with the default `Delete` reclaim behavior, the
+   backing data is deleted permanently.
+
+The repository now sets `preserveResourcesOnDeletion: true` on the apps
+ApplicationSet. That means removing a generated Application leaves its live
+resources running; any cleanup is a deliberate manual step after backup and
+verification, not a side effect of a generator edit.
+
+Lessons from the incident:
+
+- Treat Application ownership transfers like data-plane changes, not harmless
+  YAML reshuffling.
+- Confirm stateful apps have a current, restorable backup before changing their
+  Application source or generator membership. Use
+  [backup-verification.md](backup-verification.md) as the pre-flight gate.
+- Pushed Secrets are namespace-scoped. If a namespace is cascade-deleted and then
+  recreated, those Secrets are gone too; re-run `scripts/sync-secrets.sh <app>`
+  before expecting workloads to start.
+- Longhorn-backed PVCs may be recoverable from Longhorn backups, but `local-path`
+  PVCs with delete reclaim are not a backup strategy.
+
+Before deleting, excluding, renaming, or transferring any generated Application:
+
+```sh
+kubectl -n argocd get applicationset apps -o jsonpath='{.spec.syncPolicy.preserveResourcesOnDeletion}{"\n"}'
+kubectl -n argocd get app <app> -o jsonpath='{.spec.syncPolicy.preserveResourcesOnDeletion}{"\n"}'
+kubectl -n <namespace> get pvc
+```
+
+If the first check is not `true`, stop and add the safety setting before syncing
+the generator change. If the app is already explicit, set the same safety on that
+Application before deleting or replacing it.
+
 ## PostgreSQL restore sketch
 
 ```sh

--- a/docs/runbooks/heavy-rollouts.md
+++ b/docs/runbooks/heavy-rollouts.md
@@ -1,0 +1,84 @@
+# Runbook: heavy rollouts
+
+Use this for storage-heavy or CPU-heavy changes on the Raspberry Pi cluster:
+large image pulls, database cold starts, InnoDB initialization, Longhorn rebuilds,
+and any rollout that can saturate a 4GB worker. The uptime-MariaDB rollout
+overloaded a node hard enough that DNS dropped when MetalLB speaker health was
+impacted; treat that as the failure mode to avoid.
+
+## Before the rollout
+
+- Schedule a maintenance window for anything that can cold-start databases or
+  pull multi-GB images.
+- Keep Pi-hole/dnsdist/MetalLB stable: do not combine DNS changes with heavy
+  application rollouts.
+- Confirm the target app has resource requests/limits, probes, and a PDB where
+  possible.
+- Check nodes before starting:
+  ```sh
+  kubectl top nodes
+  kubectl -n metallb-system get pods -o wide
+  kubectl get nodes
+  ```
+- Watch the rollout from another terminal:
+  ```sh
+  kubectl get nodes -w
+  kubectl -n metallb-system get pods -w
+  kubectl -n <namespace> get pods -o wide -w
+  ```
+
+## Pre-pull large images
+
+Pre-pull large images one node at a time so kubelet/containerd and the USB SSDs
+do not all spike during the Deployment rollout.
+
+```sh
+# Pick one node, then use a short-lived pod pinned to that node.
+kubectl run prepull-<node> \
+  --image=<image>:<tag> \
+  --restart=Never \
+  --overrides='{"spec":{"nodeName":"<node>","tolerations":[{"operator":"Exists"}],"containers":[{"name":"prepull","image":"<image>:<tag>","command":["/bin/sh","-c","sleep 5"]}]}}'
+
+kubectl wait --for=condition=Ready pod/prepull-<node> --timeout=5m || true
+kubectl delete pod/prepull-<node>
+```
+
+Repeat for the next worker only after node load and MetalLB speakers look normal.
+
+## Roll out slowly
+
+1. Sync or apply one workload at a time.
+2. Avoid concurrent cold starts on the same worker. If multiple Pods schedule on
+   one node, pause and let the first become Ready before continuing.
+3. For StatefulSets/databases, wait for storage initialization to finish before
+   allowing the next Pod to start.
+4. Watch MetalLB while the heavy workload starts:
+   ```sh
+   kubectl -n metallb-system get deploy,ds,pods -o wide
+   kubectl -n metallb-system logs deploy/metallb-controller --tail=50
+   ```
+5. Check DNS externally during the rollout:
+   ```sh
+   dig @192.168.52.53 example.com A +short
+   ```
+
+## Stop conditions
+
+Stop the rollout and let the cluster recover if any of these happen:
+
+- A node reports MemoryPressure, DiskPressure, PIDPressure, or NotReady.
+- MetalLB controller has zero available replicas.
+- Any MetalLB speaker is unavailable or repeatedly restarting.
+- DNS queries through `192.168.52.53` fail.
+- Load average stays above CPU count for more than a few minutes.
+
+If DNS is impacted, use [break-glass.md](break-glass.md) for the router/DHCP
+fallback and keep changes minimal until MetalLB and the DNS path are stable.
+
+## After the rollout
+
+- Confirm all Pods are Ready and spread across nodes where expected.
+- Confirm MetalLB controller and speakers are healthy.
+- Confirm DNS through `192.168.52.53` and ingress through `192.168.52.80`.
+- Record any image, database, or storage step that caused pressure so the next
+  rollout can pre-pull or schedule around it.

--- a/platform/monitoring/helm-values.yaml
+++ b/platform/monitoring/helm-values.yaml
@@ -268,6 +268,121 @@ defaultRules:
     kubernetesStorage: false
     kubernetesSystem: true
     kubeScheduler: false
+
+# Additive post-incident alerts. These are intentionally early-warning rules for
+# the DNS-outage failure mode: a Pi gets overloaded, MetalLB drops the DNS VIP,
+# and the node only becomes obviously NotReady after user traffic is impacted.
+additionalPrometheusRulesMap:
+  node-resilience:
+    groups:
+      - name: homelab.node-resilience
+        rules:
+          - alert: HomelabNodeHighLoadAverage
+            expr: |
+              (
+                node_load15{job=~".*node-exporter.*"}
+                / on(instance)
+                count by (instance) (node_cpu_seconds_total{job=~".*node-exporter.*", mode="idle"})
+              ) > 1.5
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Node load is high before kubelet marks it NotReady"
+              description: "15-minute load on {{ $labels.instance }} is more than 1.5x CPU count. Pause heavy rollouts and check image pulls, database cold starts, and Longhorn I/O."
+
+          - alert: HomelabNodeMemoryPressureEarly
+            expr: |
+              (
+                1 - (
+                  node_memory_MemAvailable_bytes{job=~".*node-exporter.*"}
+                  / node_memory_MemTotal_bytes{job=~".*node-exporter.*"}
+                )
+              ) > 0.90
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Node memory pressure is high"
+              description: "{{ $labels.instance }} has less than 10% available memory for 10 minutes. On 4GB workers this can precede kubelet eviction or MetalLB speaker instability."
+
+          - alert: HomelabNodeTemperatureHigh
+            expr: |
+              max by (instance, chip, sensor) (
+                node_hwmon_temp_celsius{job=~".*node-exporter.*"}
+              ) > 75
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Raspberry Pi node temperature is high"
+              description: "{{ $labels.instance }} reports {{ $value }}C via node_hwmon_temp_celsius. If this metric is absent, enable a Pi thermal collector or rpi exporter before relying on temperature alerts."
+
+          - alert: HomelabNodeCpuThrottling
+            expr: |
+              increase(node_cpu_core_throttles_total{job=~".*node-exporter.*"}[15m]) > 0
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Node CPU throttling detected"
+              description: "{{ $labels.instance }} is reporting CPU throttling. This metric depends on node-exporter's thermal/throttling collector; absence is a monitoring gap for Raspberry Pi throttling."
+
+          - alert: HomelabNodePressureCondition
+            expr: |
+              kube_node_status_condition{
+                condition=~"MemoryPressure|DiskPressure|PIDPressure",
+                status="true"
+              } == 1
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Kubernetes reports node pressure"
+              description: "{{ $labels.node }} has {{ $labels.condition }} for 5 minutes. Treat this as pre-NotReady risk for DNS and storage workloads."
+
+          - alert: HomelabKubeletTargetDown
+            expr: |
+              up{job=~".*kubelet.*"} == 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Kubelet scrape target is down"
+              description: "Prometheus cannot scrape kubelet on {{ $labels.instance }}. If kubelet scraping is not enabled, this rule will not fire; NodePressure alerts still cover kube-state-metrics conditions."
+
+      - name: homelab.metallb-resilience
+        rules:
+          - alert: HomelabMetalLBControllerUnavailable
+            expr: |
+              kube_deployment_status_replicas_available{
+                namespace="metallb-system",
+                deployment="metallb-controller"
+              } < 1
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "MetalLB controller is unavailable"
+              description: "MetalLB controller has no available replicas. DNS VIP recovery may be impaired during node overload."
+
+          - alert: HomelabMetalLBSpeakerUnavailable
+            expr: |
+              kube_daemonset_status_number_available{
+                namespace="metallb-system",
+                daemonset="metallb-speaker"
+              }
+              <
+              kube_daemonset_status_desired_number_scheduled{
+                namespace="metallb-system",
+                daemonset="metallb-speaker"
+              }
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "MetalLB speaker is unavailable on one or more nodes"
+              description: "Available MetalLB speakers are below desired scheduled speakers. The DNS VIP depends on speaker health during failover and overload."
 # Node Exporter configuration
 nodeExporter:
   enabled: true

--- a/scripts/sync-secrets.sh
+++ b/scripts/sync-secrets.sh
@@ -20,6 +20,14 @@ set -euo pipefail
 #   scripts/sync-secrets.sh shlink          # sync one (template basename)
 #   scripts/sync-secrets.sh postgres-app    # sync only the shared postgres fan-out
 #   scripts/sync-secrets.sh --dry-run       # render + validate, apply nothing
+#   scripts/sync-secrets.sh --verify        # read-only: report missing live Secrets
+#   scripts/sync-secrets.sh --reconcile     # push only missing live Secrets
+#
+# Modes:
+#   default      Resolve all selected 1Password refs, then apply selected Secrets.
+#   --dry-run    Resolve all selected 1Password refs, but do not apply anything.
+#   --verify     Do not call op or apply; only kubectl-get expected Secret names.
+#   --reconcile  Check expected Secret names first, then apply only missing ones.
 #
 # Env:
 #   OP_VAULT    1Password vault holding homelab items (default: homelab)
@@ -37,13 +45,39 @@ PG_LABEL="postgres-client=true"
 OP_ARGS=()
 [[ -n "${OP_ACCOUNT:-}" ]] && OP_ARGS=(--account "${OP_ACCOUNT}")
 
+MODE=sync
+MODE_SET=false
 DRY_RUN=false
 TARGET=""
 for arg in "$@"; do
   case "$arg" in
-    --dry-run) DRY_RUN=true ;;
+    --dry-run)
+      if [[ "${MODE_SET}" == true ]]; then
+        echo "Only one of --dry-run, --verify, or --reconcile may be used." >&2
+        exit 2
+      fi
+      MODE_SET=true
+      DRY_RUN=true
+      MODE=dry-run
+      ;;
+    --verify)
+      if [[ "${MODE_SET}" == true ]]; then
+        echo "Only one of --dry-run, --verify, or --reconcile may be used." >&2
+        exit 2
+      fi
+      MODE_SET=true
+      MODE=verify
+      ;;
+    --reconcile)
+      if [[ "${MODE_SET}" == true ]]; then
+        echo "Only one of --dry-run, --verify, or --reconcile may be used." >&2
+        exit 2
+      fi
+      MODE_SET=true
+      MODE=reconcile
+      ;;
     -h | --help)
-      sed -n '3,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '3,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     -*)
@@ -54,22 +88,28 @@ for arg in "$@"; do
   esac
 done
 
+if [[ "${MODE}" == "verify" || "${MODE}" == "reconcile" ]]; then
+  section "Secret ${MODE} check"
+else
+  section "1Password push-sync (vault: ${OP_VAULT})"
+fi
+
 # --- preconditions -----------------------------------------------------------
-command -v op >/dev/null 2>&1 || {
-  echo "op (1Password CLI) is required. Install it and sign in." >&2
-  exit 1
-}
+if [[ "${MODE}" != "verify" ]]; then
+  command -v op >/dev/null 2>&1 || {
+    echo "op (1Password CLI) is required. Install it and sign in." >&2
+    exit 1
+  }
+  if ! op "${OP_ARGS[@]}" account get >/dev/null 2>&1; then
+    echo "No usable 1Password session. Run 'eval \$(op signin)' (or enable the" >&2
+    echo "desktop app CLI integration), then retry. Set OP_ACCOUNT for multi-account." >&2
+    exit 1
+  fi
+fi
 command -v kubectl >/dev/null 2>&1 || {
   echo "kubectl is required." >&2
   exit 1
 }
-
-section "1Password push-sync (vault: ${OP_VAULT})"
-if ! op "${OP_ARGS[@]}" account get >/dev/null 2>&1; then
-  echo "No usable 1Password session. Run 'eval \$(op signin)' (or enable the" >&2
-  echo "desktop app CLI integration), then retry. Set OP_ACCOUNT for multi-account." >&2
-  exit 1
-fi
 
 if [[ "${DRY_RUN}" == false ]]; then
   if ! kubectl version >/dev/null 2>&1; then
@@ -98,7 +138,18 @@ else
     < <(find "${TEMPLATE_DIR}" -maxdepth 1 -name '*.yaml' | sort)
 fi
 
-template_ns() { grep -m1 -E '^\s*namespace:' "$1" | awk '{print $2}'; }
+template_metadata() {
+  local field=$1
+  local tpl=$2
+  awk -v field="${field}:" '
+    $1 == "metadata:" { in_metadata = 1; next }
+    in_metadata && $0 ~ /^[^[:space:]]/ { in_metadata = 0 }
+    in_metadata && $1 == field { print $2; exit }
+  ' "$tpl"
+}
+
+template_name() { template_metadata name "$1"; }
+template_ns() { template_metadata namespace "$1"; }
 
 ensure_namespace() {
   local ns=$1
@@ -107,23 +158,137 @@ ensure_namespace() {
   kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -
 }
 
-# --- validation pass (resolve everything before touching the cluster) --------
-section "Validating 1Password references"
-for tpl in "${TEMPLATES[@]}"; do
-  rel=${tpl#"${REPO_ROOT}/"}
+verify_secret() {
+  local name=$1
+  local ns=$2
+  kubectl get secret "$name" -n "$ns" >/dev/null 2>&1
+}
+
+resolve_template() {
+  local tpl=$1
+  local rel=${tpl#"${REPO_ROOT}/"}
   log "Resolving ${rel}"
   if ! op "${OP_ARGS[@]}" inject -f -i "$tpl" >/dev/null 2>&1; then
     echo "FAIL: could not resolve 1Password references in ${rel}." >&2
     echo "      Check the item/field labels exist in vault '${OP_VAULT}'." >&2
     exit 1
   fi
-done
-if [[ "${SYNC_PG}" == true ]]; then
+}
+
+resolve_postgres() {
   log "Resolving $(basename "${PG_TEMPLATE}")"
   if ! op "${OP_ARGS[@]}" inject -f -i "${PG_TEMPLATE}" >/dev/null 2>&1; then
     echo "FAIL: could not resolve postgres/password in vault '${OP_VAULT}'." >&2
     exit 1
   fi
+}
+
+# --- verify/reconcile pass ---------------------------------------------------
+if [[ "${MODE}" == "verify" || "${MODE}" == "reconcile" ]]; then
+  PRESENT_COUNT=0
+  MISSING_COUNT=0
+  MISSING_TEMPLATES=()
+  MISSING_PG_NS=()
+
+  section "Checking expected live Secrets"
+  for tpl in "${TEMPLATES[@]}"; do
+    rel=${tpl#"${REPO_ROOT}/"}
+    name=$(template_name "$tpl")
+    ns=$(template_ns "$tpl")
+    [[ -n "$name" ]] || {
+      echo "FAIL: no Secret name found in ${rel}." >&2
+      exit 1
+    }
+    [[ -n "$ns" ]] || {
+      echo "FAIL: no namespace found in ${rel}." >&2
+      exit 1
+    }
+    if verify_secret "$name" "$ns"; then
+      log "PRESENT ${ns}/${name} (${rel})"
+      PRESENT_COUNT=$((PRESENT_COUNT + 1))
+    else
+      log "MISSING ${ns}/${name} (${rel})"
+      MISSING_COUNT=$((MISSING_COUNT + 1))
+      MISSING_TEMPLATES+=("$tpl")
+    fi
+  done
+
+  if [[ "${SYNC_PG}" == true || "${TARGET}" == "postgres-app" ]]; then
+    pg_name=$(template_name "${PG_TEMPLATE}")
+    [[ -n "$pg_name" ]] || {
+      echo "FAIL: no Secret name found in $(basename "${PG_TEMPLATE}")." >&2
+      exit 1
+    }
+    mapfile -t PG_NS < <(kubectl get namespaces -l "${PG_LABEL}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+    if [[ ${#PG_NS[@]} -eq 0 ]]; then
+      log "No namespaces labeled ${PG_LABEL}; no postgres-app fan-out expected."
+    else
+      for ns in "${PG_NS[@]}"; do
+        if verify_secret "$pg_name" "$ns"; then
+          log "PRESENT ${ns}/${pg_name} (${PG_LABEL})"
+          PRESENT_COUNT=$((PRESENT_COUNT + 1))
+        else
+          log "MISSING ${ns}/${pg_name} (${PG_LABEL})"
+          MISSING_COUNT=$((MISSING_COUNT + 1))
+          MISSING_PG_NS+=("$ns")
+        fi
+      done
+    fi
+  fi
+
+  section "Secret ${MODE} summary"
+  log "Present: ${PRESENT_COUNT}; missing: ${MISSING_COUNT}"
+
+  if [[ "${MODE}" == "verify" ]]; then
+    if [[ ${MISSING_COUNT} -gt 0 ]]; then
+      echo "FAIL: ${MISSING_COUNT} expected Secret(s) are missing." >&2
+      exit 1
+    fi
+    section "Secret verify complete — all expected Secrets are present"
+    exit 0
+  fi
+
+  if [[ ${MISSING_COUNT} -eq 0 ]]; then
+    section "Secret reconcile complete — nothing missing"
+    exit 0
+  fi
+
+  section "Validating missing 1Password references"
+  for tpl in "${MISSING_TEMPLATES[@]}"; do
+    resolve_template "$tpl"
+  done
+  if [[ ${#MISSING_PG_NS[@]} -gt 0 ]]; then
+    resolve_postgres
+  fi
+  log "Missing references resolved."
+
+  section "Reconciling missing Secrets"
+  for tpl in "${MISSING_TEMPLATES[@]}"; do
+    rel=${tpl#"${REPO_ROOT}/"}
+    ns=$(template_ns "$tpl")
+    ensure_namespace "$ns"
+    log "Applying missing ${rel} -> namespace ${ns}"
+    op "${OP_ARGS[@]}" inject -f -i "$tpl" | kubectl apply -f -
+  done
+  if [[ ${#MISSING_PG_NS[@]} -gt 0 ]]; then
+    rendered=$(op "${OP_ARGS[@]}" inject -f -i "${PG_TEMPLATE}")
+    for ns in "${MISSING_PG_NS[@]}"; do
+      log "Applying missing postgres-app -> namespace ${ns}"
+      printf '%s\n' "${rendered}" | sed "s/__NAMESPACE__/${ns}/g" | kubectl apply -f -
+    done
+  fi
+
+  section "Secret reconcile complete"
+  exit 0
+fi
+
+# --- validation pass (resolve everything before touching the cluster) --------
+section "Validating 1Password references"
+for tpl in "${TEMPLATES[@]}"; do
+  resolve_template "$tpl"
+done
+if [[ "${SYNC_PG}" == true ]]; then
+  resolve_postgres
 fi
 pass_msg="All references resolved."
 log "${pass_msg}"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -278,11 +278,135 @@ PY
   fi
 }
 
+check_appset_preserve_policy() {
+  section "ApplicationSet deletion safety"
+  set +e
+  python3 - "$REPO_ROOT" <<'PY'
+import os, sys
+
+root = sys.argv[1]
+path = os.path.join(root, 'clusters', 'rpi', 'apps-appset.yml')
+rel = os.path.relpath(path, root)
+with open(path, encoding='utf-8') as fh:
+    text = fh.read()
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+def scalar_true(value):
+    return value.split('#', 1)[0].strip().strip('"\'').lower() == 'true'
+
+def stripped_docs(raw):
+    import re
+    return [doc for doc in re.split(r'(?m)^---\s*$', raw) if doc.strip()]
+
+def fallback_doc_kind(doc):
+    import re
+    match = re.search(r'(?m)^kind:\s*["\']?([^"\'\n#]+)', doc)
+    return match.group(1).strip() if match else None
+
+def fallback_doc_name(doc):
+    import re
+    match = re.search(r'(?m)^metadata:\s*\n(?:\s+.*\n)*?\s+name:\s*["\']?([^"\'\n#]+)', doc)
+    return match.group(1).strip() if match else '<unnamed>'
+
+def fallback_spec_sync_policy_preserve(doc):
+    stack = []
+    for raw_line in doc.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith('#'):
+            continue
+        if ':' not in raw_line:
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(' '))
+        key, value = raw_line.strip().split(':', 1)
+        key = key.strip().strip('"\'')
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        stack.append((indent, key))
+        path = [item[1] for item in stack]
+        if path == ['spec', 'syncPolicy', 'preserveResourcesOnDeletion']:
+            return scalar_true(value)
+    return False
+
+if yaml:
+    docs = [doc for doc in yaml.safe_load_all(text) if isinstance(doc, dict)]
+    appsets = [doc for doc in docs if doc.get('kind') == 'ApplicationSet']
+    if not appsets:
+        print(f'{rel}: expected an ApplicationSet document.', file=sys.stderr)
+        sys.exit(1)
+
+    appset = appsets[0]
+    explicit_apps = [
+        doc.get('metadata', {}).get('name', '<unnamed>')
+        for doc in docs
+        if doc.get('kind') == 'Application'
+    ]
+
+    def has_exclude_true(node):
+        if isinstance(node, dict):
+            if node.get('exclude') is True:
+                return True
+            return any(has_exclude_true(value) for value in node.values())
+        if isinstance(node, list):
+            return any(has_exclude_true(value) for value in node)
+        return False
+
+    has_generator_excludes = has_exclude_true(appset.get('spec', {}).get('generators', []))
+    preserve = appset.get('spec', {}).get('syncPolicy', {}).get('preserveResourcesOnDeletion') is True
+else:
+    docs = stripped_docs(text)
+    appset_docs = [doc for doc in docs if fallback_doc_kind(doc) == 'ApplicationSet']
+    if not appset_docs:
+        print(f'{rel}: expected an ApplicationSet document.', file=sys.stderr)
+        sys.exit(1)
+    appset_doc = appset_docs[0]
+    explicit_apps = [
+        fallback_doc_name(doc)
+        for doc in docs
+        if fallback_doc_kind(doc) == 'Application'
+    ]
+    has_generator_excludes = any(
+        scalar_true(line.split(':', 1)[1])
+        for line in appset_doc.splitlines()
+        if line.strip().startswith('exclude:')
+    )
+    preserve = fallback_spec_sync_policy_preserve(appset_doc)
+
+uses_ownership_transfer = bool(explicit_apps) or has_generator_excludes
+
+# Excluding generator paths or defining explicit Applications transfers ownership
+# away from the ApplicationSet. Without this flag, the controller can cascade
+# delete generated Applications and their live resources (including PVCs).
+if uses_ownership_transfer and not preserve:
+    details = []
+    if explicit_apps:
+        details.append('explicit Application objects: ' + ', '.join(explicit_apps))
+    if has_generator_excludes:
+        details.append('generator exclude: true entries')
+    print(
+        f'{rel}: ownership-transfer pattern in use ({ "; ".join(details) }) '
+        'but spec.syncPolicy.preserveResourcesOnDeletion is not true.',
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+  local rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    fail "ApplicationSet preserveResourcesOnDeletion guard failed."
+  else
+    pass "ApplicationSet ownership-transfer paths preserve live resources on deletion."
+  fi
+}
+
 check_kustomize
 check_helm
 check_kubeconform
 check_secrets
 check_prune_policy
+check_appset_preserve_policy
 
 section "Validation summary"
 log "Warnings: ${WARNINGS}"

--- a/scripts/verify-backup.sh
+++ b/scripts/verify-backup.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+source "${REPO_ROOT}/_shared/echo.sh"
+
+FAILURES=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/verify-backup.sh <namespace> [pvc]
+
+Read-only backup gate for data-risking changes.
+
+Checks every PVC in <namespace>, or one named [pvc], and exits 0 only when each
+PVC is Longhorn-backed, assigned to a Longhorn backup RecurringJob group, and has
+evidence that at least one backup has completed.
+
+Examples:
+  scripts/verify-backup.sh uptime
+  scripts/verify-backup.sh uptime uptime-data
+USAGE
+}
+
+need_command() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+fail_pvc() {
+  local pvc=$1
+  local message=$2
+  echo "FAIL: ${pvc}: ${message}" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+pass_pvc() {
+  local pvc=$1
+  local message=$2
+  log "PASS: ${pvc}: ${message}"
+}
+
+warn_pvc() {
+  local pvc=$1
+  local message=$2
+  echo "WARN: ${pvc}: ${message}" >&2
+}
+
+if [[ ${1:-} == "--help" || ${1:-} == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+if ! need_command kubectl; then
+  echo "FAIL: kubectl is required for read-only backup verification." >&2
+  exit 1
+fi
+
+NAMESPACE=$1
+REQUESTED_PVC=${2:-}
+
+section "Loading Longhorn backup jobs"
+if ! BACKUP_JOBS=$(kubectl -n longhorn-system get recurringjobs.longhorn.io -o json | python3 -c '
+import json, sys
+for job in json.load(sys.stdin).get("items", []):
+    spec = job.get("spec", {}) or {}
+    if spec.get("task") != "backup":
+        continue
+    name = job.get("metadata", {}).get("name", "<unnamed>")
+    status = job.get("status", {}) or {}
+    try:
+        execution_count = int(status.get("executionCount") or 0)
+    except (TypeError, ValueError):
+        execution_count = 0
+    for group in spec.get("groups") or []:
+        print(f"{group}\t{name}\t{execution_count}")
+'); then
+  echo "FAIL: could not list Longhorn RecurringJobs in longhorn-system." >&2
+  exit 1
+fi
+
+if [[ -z "${BACKUP_JOBS}" ]]; then
+  echo "FAIL: no Longhorn backup RecurringJobs found in longhorn-system." >&2
+  exit 1
+fi
+
+log "Backup RecurringJob groups: $(awk -F '\t' '{print $1 " (" $2 ", executions=" $3 ")"}' <<<"${BACKUP_JOBS}" | paste -sd ', ' -)"
+
+section "Resolving PVCs"
+if [[ -n "${REQUESTED_PVC}" ]]; then
+  if ! PVC_ROWS=$(kubectl -n "${NAMESPACE}" get pvc "${REQUESTED_PVC}" -o json | python3 -c '
+import json, sys
+pvc = json.load(sys.stdin)
+name = pvc.get("metadata", {}).get("name", "")
+spec = pvc.get("spec", {}) or {}
+print("\t".join([name, spec.get("volumeName") or "", spec.get("storageClassName") or ""]))
+'); then
+    echo "FAIL: could not read PVC ${NAMESPACE}/${REQUESTED_PVC}." >&2
+    exit 1
+  fi
+else
+  if ! PVC_ROWS=$(kubectl -n "${NAMESPACE}" get pvc -o json | python3 -c '
+import json, sys
+for pvc in json.load(sys.stdin).get("items", []):
+    name = pvc.get("metadata", {}).get("name", "")
+    spec = pvc.get("spec", {}) or {}
+    print("\t".join([name, spec.get("volumeName") or "", spec.get("storageClassName") or ""]))
+'); then
+    echo "FAIL: could not list PVCs in namespace ${NAMESPACE}." >&2
+    exit 1
+  fi
+fi
+
+if [[ -z "${PVC_ROWS}" ]]; then
+  echo "FAIL: no PVCs found in namespace ${NAMESPACE}." >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r pvc pv pvc_storage_class; do
+  [[ -n "${pvc}" ]] || continue
+  section "Checking ${NAMESPACE}/${pvc}"
+
+  if [[ -z "${pv}" ]]; then
+    fail_pvc "${pvc}" "PVC is not bound to a PV yet; no backup can be verified."
+    continue
+  fi
+
+  if ! pv_storage_class=$(kubectl get pv "${pv}" -o jsonpath='{.spec.storageClassName}'); then
+    fail_pvc "${pvc}" "could not resolve bound PV ${pv}."
+    continue
+  fi
+
+  storage_class=${pv_storage_class:-${pvc_storage_class}}
+  log "PVC ${NAMESPACE}/${pvc} -> PV ${pv} (storageClass=${storage_class:-<unset>})"
+
+  if [[ "${storage_class}" != "longhorn" ]]; then
+    warn_pvc "${pvc}" "LOUD WARNING: storageClass '${storage_class:-<unset>}' is NOT covered by Longhorn backups. Treat this data as unprotected."
+    FAILURES=$((FAILURES + 1))
+    continue
+  fi
+
+  if ! volume_json=$(kubectl -n longhorn-system get volumes.longhorn.io "${pv}" -o json 2>/dev/null); then
+    fail_pvc "${pvc}" "Longhorn volume ${pv} was not found."
+    continue
+  fi
+
+  volume_info=$(printf '%s' "${volume_json}" | python3 -c '
+import json, sys
+volume = json.load(sys.stdin)
+labels = volume.get("metadata", {}).get("labels", {}) or {}
+groups = []
+for key, value in labels.items():
+    prefix = "recurring-job-group.longhorn.io/"
+    if key.startswith(prefix) and str(value).lower() == "enabled":
+        groups.append(key[len(prefix):])
+last_backup = ((volume.get("status", {}) or {}).get("lastBackup") or "")
+print("\t".join([",".join(sorted(groups)), last_backup]))
+')
+  IFS=$'\t' read -r volume_groups last_backup <<<"${volume_info}"
+
+  if [[ -z "${volume_groups}" ]]; then
+    fail_pvc "${pvc}" "Longhorn volume ${pv} has no recurring-job-group.longhorn.io/<group>: enabled label."
+    continue
+  fi
+
+  configured_group=""
+  configured_jobs=""
+  max_execution_count=0
+  IFS=',' read -ra groups <<<"${volume_groups}"
+  for group in "${groups[@]}"; do
+    jobs_for_group=$(awk -F '\t' -v group="${group}" '$1 == group {print $2}' <<<"${BACKUP_JOBS}" | paste -sd ',' -)
+    group_execution_count=$(awk -F '\t' -v group="${group}" '$1 == group && ($3 + 0) > max {max = $3 + 0} END {print max + 0}' <<<"${BACKUP_JOBS}")
+    if [[ -n "${jobs_for_group}" ]]; then
+      configured_group=${group}
+      configured_jobs=${jobs_for_group}
+      max_execution_count=${group_execution_count}
+      break
+    fi
+  done
+
+  if [[ -z "${configured_group}" ]]; then
+    fail_pvc "${pvc}" "Longhorn groups '${volume_groups}' are enabled on the volume, but none maps to a task: backup RecurringJob."
+    continue
+  fi
+
+  log "Backup configured: group '${configured_group}' via job(s) ${configured_jobs}."
+
+  if [[ -n "${last_backup}" ]]; then
+    pass_pvc "${pvc}" "backup completed; Longhorn lastBackup=${last_backup}."
+  elif [[ ${max_execution_count} -gt 0 ]]; then
+    pass_pvc "${pvc}" "backup job has completed ${max_execution_count} time(s); volume lastBackup is empty/unavailable."
+  else
+    fail_pvc "${pvc}" "backup is configured, but no completed backup was observed (executionCount=0 and lastBackup empty)."
+  fi
+done <<<"${PVC_ROWS}"
+
+section "Backup verification summary"
+if [[ ${FAILURES} -gt 0 ]]; then
+  echo "Backup verification failed for ${FAILURES} PVC check(s)." >&2
+  exit 1
+fi
+
+log "Backup verification passed for namespace ${NAMESPACE}${REQUESTED_PVC:+ PVC ${REQUESTED_PVC}}."


### PR DESCRIPTION
# Sprint 4 — Retro Actions

Implements the agent-executable retro action items in one PR (P1+P2, plus the P3 DNS doc), per the 2026-06-27 retrospective. **Nothing here is applied/merged/rotated automatically** — repo changes only, for your review.

## What's in here

| Issue | Pri | Change |
|---|---|---|
| #65 | P1 | `validate.sh` guard: fails if `apps-appset.yml` uses ownership-transfer (excludes / explicit Apps) without `preserveResourcesOnDeletion: true` |
| #71 | P1 | `scripts/verify-backup.sh` (read-only backup gate) + `docs/runbooks/backup-verification.md` |
| #66 | P1 | Safe multi-agent git-workflow rules in `copilot-instructions.md` |
| #62 | P1 | **Gated** Ansible node-resilience: kubelet reserved/eviction (4GB vs 8GB), writeback sysctls 10/5, vestigial `/var/swap` removal — all behind `k3s_apply`/`base_apply` (default off) |
| #54 | P1 | kube-prometheus-stack alerts: node load, memory pressure, thermal/throttle, kubelet/NotReady risk, MetalLB availability |
| #68 | P2 | `docs/runbooks/heavy-rollouts.md` |
| #67 | P2 | `sync-secrets.sh` `--verify` / `--reconcile` (default behavior unchanged) |
| #23 | P1 | `docs/runbooks/credential-rotation.md` (prep — rotation itself is yours) |
| #69 | P2 | `docs/runbooks/argocd-outofsync.md` (3 drift classes) + disaster-recovery cascade-delete section |
| #70 | P3 | `docs/dns-architecture.md` |

## Verification
- `scripts/validate.sh` ✅ — including the **new "ApplicationSet deletion safety" guard** (PASS) and the secret scan / prune-selfHeal guards.
- `scripts/verify-backup.sh uptime` ✅ — functionally confirmed both uptime PVCs are Longhorn-backed, in the `default` group, with completed backups (exit 0).
- **Volume backup audit (read-only):** all **13** stateful PVCs are on Longhorn (no `local-path` remaining), all in the `default` backup group, all with a completed backup (~07:00 UTC today). **0 gaps.**

## ⚠️ Requires YOU after merge (not done here)
1. **#62 node tuning** — apply via Ansible carefully: `ansible-playbook adopt.yml --check --diff --limit <host>` first (read-only), then enable `k3s_apply`/`base_apply` and roll **one node at a time** watching DNS/MetalLB. Disruptive (kubelet restart).
2. **#54 alerts** — manually sync the `monitoring` app in ArgoCD to load the new PrometheusRules.
3. **#23** — rotate the two leaked credentials in 1Password + the services (history scrub optional). Agent cannot do this.
4. **#54 cooling** — install the permanent fan when it arrives.
5. Sync any other apps whose manifests changed once you've reviewed.

## Notes
- All work produced by the specialist agents on disjoint paths; coordinator owns all commits (per the #66 rule, now codified).
- Backups verified clean before/independently of this work — see audit above.
