### PR TITLE
feat(secrets): optional 1Password service account for non-interactive sync (#74)

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -8,10 +8,16 @@ authenticates to 1Password, so there is no operator and no runtime dependency on
 the push script non-interactively; its token never goes into the cluster.
 
 > **Why push, not pull?** External Secrets Operator's 1Password providers
-> (`onepasswordSDK`/Connect) both require a **Business** service account. This
-> account is a **Family** plan, which cannot create service accounts. The
-> push-sync model sidesteps that entirely — the operator's own signed-in `op`
-> session resolves the references, so a Family (or even personal) plan works.
+> (`onepasswordSDK`/Connect) pull from 1Password's hosted API and need a
+> credential with direct **SaaS access** — a Connect server or a Business/Teams
+> service account — deployed *inside* the cluster, a permanent runtime dependency
+> on 1Password. A Family plan *can* create a service account, but only for
+> **local desktop CLI** use (`op` with `OP_SERVICE_ACCOUNT_TOKEN`), not the
+> hosted SaaS access ESO requires. The push-sync model only ever uses the local
+> `op` CLI, so it works on a Family (or personal) plan — and every form of
+> 1Password auth (an interactive `op` session, or the optional **read-only**
+> workstation service account described below) stays on the workstation and
+> never enters the cluster.
 
 The guiding rule is unchanged: **only genuinely private values go to 1Password.**
 Non-secret, cluster-specific values (hostnames, LAN IPs, timezone, UID/GID,
@@ -76,9 +82,13 @@ Operator setup (do this manually, not from an agent):
 
 1. Create a 1Password service account with **read-only** access to only the
    `homelab` vault.
-2. Store its token in macOS Keychain, using a placeholder here for the value:
+2. Store its token in macOS Keychain. Copy the full `ops_…` token to your
+   clipboard first, then store it *from the clipboard* — a very long token can be
+   silently truncated if pasted into an interactive prompt:
    ```sh
-   security add-generic-password -a "$USER" -s "op-service-token-homelab" -w "<token>" -U
+   pbpaste | wc -c   # sanity-check length (~800+ chars) before storing
+   security add-generic-password -U -a "$USER" -s "op-service-token-homelab" -w "$(pbpaste)"
+   pbcopy </dev/null # clear the clipboard afterward
    ```
 3. Never commit or print the token. Rotate it immediately if it is exposed.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -3,8 +3,9 @@
 Secrets are intentionally lightweight and **homelab-friendly**: **1Password is
 the source of truth**, and a small workstation script **pushes** the private
 values into the cluster as Kubernetes Secrets. Nothing in the cluster
-authenticates to 1Password, so there is no service-account token, no operator,
-and no runtime dependency on 1Password at all.
+authenticates to 1Password, so there is no operator and no runtime dependency on
+1Password at all. An optional workstation-only service account can authenticate
+the push script non-interactively; its token never goes into the cluster.
 
 > **Why push, not pull?** External Secrets Operator's 1Password providers
 > (`onepasswordSDK`/Connect) both require a **Business** service account. This
@@ -57,11 +58,43 @@ Environment:
 | Var | Default | Purpose |
 | --- | --- | --- |
 | `OP_VAULT` | `homelab` | 1Password vault holding the homelab items. |
-| `OP_ACCOUNT` | _(unset)_ | Account shorthand / sign-in address for multi-account `op` setups (e.g. `themartinezfamily.1password.com`). |
+| `OP_ACCOUNT` | _(unset)_ | Account shorthand / sign-in address for multi-account interactive `op` setups (e.g. `themartinezfamily.1password.com`). |
+| `OP_SERVICE_TOKEN_KEYCHAIN_ITEM` | `op-service-token-homelab` | macOS Keychain item name for the optional service-account token. |
 
 The script runs a **validation pass first** — it `op inject`s every selected
 template and aborts before touching the cluster if any reference fails to
 resolve, so a typo never leaves you with a half-applied set of Secrets.
+
+
+## Optional: Non-interactive sync via a 1Password service account
+
+The default path remains an interactive `op` session, but operators may configure
+a read-only service account to avoid per-item biometric prompts. This is useful
+for hands-free disaster-recovery re-pushes after etcd loss or cluster rebuilds.
+
+Operator setup (do this manually, not from an agent):
+
+1. Create a 1Password service account with **read-only** access to only the
+   `homelab` vault.
+2. Store its token in macOS Keychain, using a placeholder here for the value:
+   ```sh
+   security add-generic-password -a "$USER" -s "op-service-token-homelab" -w "<token>" -U
+   ```
+3. Never commit or print the token. Rotate it immediately if it is exposed.
+
+When `scripts/sync-secrets.sh` runs outside `--verify`, it first checks whether
+`OP_SERVICE_ACCOUNT_TOKEN` is already set. If not, and macOS Keychain is
+available, it reads the configured Keychain item into that environment variable
+at runtime. If no service-account token is available, the script falls back to
+the existing interactive `op` session behavior.
+
+Use `OP_SERVICE_TOKEN_KEYCHAIN_ITEM` to override the Keychain item name when
+needed. Service-account auth intentionally does not pass `OP_ACCOUNT`, because
+`OP_SERVICE_ACCOUNT_TOKEN` selects the account context.
+
+Keep the service account least-privilege: read-only, scoped only to `homelab`,
+and independently revocable from any human operator account. Rotate the token on
+a regular schedule and after operator workstation changes.
 
 ## The 1Password item model (one item per app)
 

--- a/scripts/sync-secrets.sh
+++ b/scripts/sync-secrets.sh
@@ -5,9 +5,10 @@ set -euo pipefail
 #
 # This is the homelab-friendly replacement for External Secrets Operator: instead
 # of the cluster pulling from 1Password (which needs a Business service account),
-# the operator PUSHES secrets from their signed-in `op` session. Nothing in the
-# cluster depends on 1Password at runtime, so a 1Password/DNS/internet outage has
-# ZERO effect on running workloads — secrets live in etcd until you re-push.
+# the operator PUSHES secrets from their signed-in `op` session or an optional
+# read-only service-account token. Nothing in the cluster depends on 1Password
+# at runtime, so a 1Password/DNS/internet outage has ZERO effect on running
+# workloads — secrets live in etcd until you re-push.
 #
 # Mechanism: every file in secrets/templates/ is a Kubernetes Secret manifest
 # whose values are 1Password references ({{ op://$OP_VAULT/item/field }}).
@@ -23,6 +24,11 @@ set -euo pipefail
 #   scripts/sync-secrets.sh --verify        # read-only: report missing live Secrets
 #   scripts/sync-secrets.sh --reconcile     # push only missing live Secrets
 #
+# Auth:
+#   Defaults to the interactive `op` session. If OP_SERVICE_ACCOUNT_TOKEN is not
+#   set and macOS Keychain has the configured item, the script exports it for
+#   non-interactive service-account auth.
+#
 # Modes:
 #   default      Resolve all selected 1Password refs, then apply selected Secrets.
 #   --dry-run    Resolve all selected 1Password refs, but do not apply anything.
@@ -30,20 +36,29 @@ set -euo pipefail
 #   --reconcile  Check expected Secret names first, then apply only missing ones.
 #
 # Env:
-#   OP_VAULT    1Password vault holding homelab items (default: homelab)
-#   OP_ACCOUNT  1Password account shorthand/sign-in address (for multi-account)
+#   OP_VAULT                         1Password vault holding homelab items (default: homelab)
+#   OP_ACCOUNT                       1Password account shorthand/sign-in address (interactive auth only)
+#   OP_SERVICE_TOKEN_KEYCHAIN_ITEM   Keychain item for optional service-account token (default: op-service-token-homelab)
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 source "${REPO_ROOT}/_shared/echo.sh"
 
 export OP_VAULT="${OP_VAULT:-homelab}"
+OP_SERVICE_TOKEN_KEYCHAIN_ITEM="${OP_SERVICE_TOKEN_KEYCHAIN_ITEM:-op-service-token-homelab}"
 TEMPLATE_DIR="${REPO_ROOT}/secrets/templates"
 PG_TEMPLATE="${REPO_ROOT}/secrets/postgres-app.tpl.yaml"
 PG_LABEL="postgres-client=true"
 
 OP_ARGS=()
-[[ -n "${OP_ACCOUNT:-}" ]] && OP_ARGS=(--account "${OP_ACCOUNT}")
+configure_op_args() {
+  OP_ARGS=()
+  # Service-account auth comes from OP_SERVICE_ACCOUNT_TOKEN; --account can conflict.
+  if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" && -n "${OP_ACCOUNT:-}" ]]; then
+    OP_ARGS=(--account "${OP_ACCOUNT}")
+  fi
+}
+configure_op_args
 
 MODE=sync
 MODE_SET=false
@@ -77,7 +92,7 @@ for arg in "$@"; do
       MODE=reconcile
       ;;
     -h | --help)
-      sed -n '3,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '3,41p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     -*)
@@ -96,13 +111,33 @@ fi
 
 # --- preconditions -----------------------------------------------------------
 if [[ "${MODE}" != "verify" ]]; then
+  if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]] && command -v security >/dev/null 2>&1; then
+    if token=$(security find-generic-password -w -s "${OP_SERVICE_TOKEN_KEYCHAIN_ITEM}" -a "${USER}" 2>/dev/null); then
+      export OP_SERVICE_ACCOUNT_TOKEN="${token}"
+      log "Using 1Password service account from Keychain (non-interactive)."
+    fi
+    unset token
+  fi
+  configure_op_args
   command -v op >/dev/null 2>&1 || {
     echo "op (1Password CLI) is required. Install it and sign in." >&2
     exit 1
   }
-  if ! op "${OP_ARGS[@]}" account get >/dev/null 2>&1; then
-    echo "No usable 1Password session. Run 'eval \$(op signin)' (or enable the" >&2
-    echo "desktop app CLI integration), then retry. Set OP_ACCOUNT for multi-account." >&2
+  # Verify auth. Service-account tokens authenticate the *session*, which
+  # `op whoami` reports reliably; `op account get` targets interactive accounts
+  # and can fail under a service-account token even when it is valid. Use a
+  # presence flag (never the token value) to choose the check.
+  op_sa_present="${OP_SERVICE_ACCOUNT_TOKEN:+1}"
+  if [[ -n "${op_sa_present}" ]]; then
+    op_auth_check=(op "${OP_ARGS[@]}" whoami)
+  else
+    op_auth_check=(op "${OP_ARGS[@]}" account get)
+  fi
+  if ! "${op_auth_check[@]}" >/dev/null 2>&1; then
+    echo "No usable 1Password auth. Run 'eval \$(op signin)' (or enable the" >&2
+    echo "desktop app CLI integration), or store a service-account token in" >&2
+    echo "Keychain item '${OP_SERVICE_TOKEN_KEYCHAIN_ITEM}'; see docs/secrets.md." >&2
+    echo "Set OP_ACCOUNT for multi-account interactive auth." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
Implements #74. Lets `scripts/sync-secrets.sh` authenticate via an optional, **read-only, `homelab`-scoped 1Password service account** so it runs **without per-item biometric prompts** — useful for hands-free disaster-recovery re-pushes. **Fully backward compatible**: the default remains the interactive `op` session.

## What
- Loads `OP_SERVICE_ACCOUNT_TOKEN` from macOS Keychain (item `op-service-token-homelab`, overridable via `OP_SERVICE_TOKEN_KEYCHAIN_ITEM`) if not already set, before the auth precondition. **Never logs the token value.**
- Auth verification picks `op whoami` when a service-account token is present (the reliable check for SA sessions) and `op account get` otherwise.
- Skips the `--account` flag when a service-account token is set (they conflict).
- Amended the "no usable auth" error to mention the service-account option.
- `docs/secrets.md`: optional setup section (read-only, homelab-only, Keychain-stored; placeholders only).

Mirrors the operator's existing Keychain convention (`op-service-token-*`). The operator creates the SA + stores the token; the cluster never authenticates to 1Password.

## Verification
- `scripts/validate.sh` passes (secret scan included — the `${VAR:-}` idiom was reworked to a `:+` presence flag so it doesn't false-positive).
- **End-to-end tested:** with the token in Keychain and no interactive `op` session, `--dry-run` correctly loaded the token from Keychain and invoked `op` non-interactively (plumbing proven).

## Operator note (not done by this PR)
Create a 1Password service account with **read-only** access to **only** the `homelab` vault; store its token in Keychain:
`security add-generic-password -U -a "$USER" -s "op-service-token-homelab" -w "$(pbpaste)"`. Read-only + single-vault + independently revocable.

## Doc follow-up
`docs/secrets.md` still contains a pre-existing line — "This account is a Family plan, which cannot create service accounts" — now in tension with this feature. Left as-is pending confirmation of the current plan/account; flagged for a follow-up doc correction.
