### PR TITLE
chore(minecraft): disable server (replicas: 0) to relieve rpi002 CPU (#77)

### DIFF
--- a/apps/minecraft/statefulset.yml
+++ b/apps/minecraft/statefulset.yml
@@ -4,7 +4,12 @@ metadata:
   name: minecraft
 spec:
   serviceName: "minecraft"
-  replicas: 1
+  # Temporarily disabled (replicas: 0) to relieve rpi002 CPU saturation — the
+  # Bedrock server image is amd64-only and runs under qemu-x86_64 emulation
+  # (~24% of a Pi core). The PVC (minecraft-pvc-minecraft-0) is retained, so
+  # world data is preserved; set back to 1 to re-enable. Tracking: #77 (move
+  # amd64 workloads to the Intel QNAP node).
+  replicas: 0
   updateStrategy:
     type: RollingUpdate
   template:


### PR DESCRIPTION
Disables the Minecraft Bedrock server by scaling its StatefulSet to `replicas: 0`, to relieve **rpi002 CPU saturation** (see #77).

## Why
The Bedrock image (`legendary-bedrock-container`) is **amd64-only**, so it runs under `qemu-x86_64` emulation on the ARM Pis — ~24% of a core on rpi002 and the single largest CPU sink there. rpi002 was at load ~18, causing cascading liveness-probe crash loops (ArgoCD `repo-server`/`server`, Longhorn `csi-plugin`, shlink/uptime/pihole).

## What
- `apps/minecraft/statefulset.yml`: `replicas: 1` → `0`, with an explanatory comment.
- **World data preserved**: the PVC `minecraft-pvc-minecraft-0` (Longhorn, `pvc-8f7eda35…`) comes from `volumeClaimTemplates`, which is **not** deleted on scale-down. Set `replicas: 1` to re-enable.
- **No ArgoCD drift**: the apps appset's `/spec/replicas` `ignoreDifferences` is scoped to `kind: Deployment`; this is a StatefulSet, so the replica change is honored.

## Verification
- Already scaled live for immediate relief — `minecraft-0` terminated gracefully, StatefulSet `0/0`, PVC still `Bound`, and the `qemu-x86_64` process is **gone** from rpi002 (0 procs).
- `scripts/validate.sh` passes; `kustomize build apps/minecraft` renders `replicas: 0`.

## Follow-up
Durable fix tracked in #77: join the Intel **QNAP TVS-x72XT** (x86_64) as a tainted k3s agent and schedule amd64 workloads (Bedrock) there natively — then this can return to `replicas: 1` pinned to that node.
