### PR TITLE
chore: Uptime Kuma tuning + squad Discord role + node-resilience watchdog fixes

### DIFF
--- a/.squad/agents/ash/charter.md
+++ b/.squad/agents/ash/charter.md
@@ -15,6 +15,7 @@
 - **Scrape & retention policy** — `scrapeInterval`/`scrapeTimeout`/`evaluationInterval`, Prometheus `retention`/`retentionSize`/`walCompression`, Alertmanager and Grafana PVC sizes. Keep retention bounded so Prometheus stays within its memory limit on 4GB nodes.
 - **Coverage** — making sure every meaningful workload exposes metrics and has a ServiceMonitor (or an `additionalScrapeConfigs` entry), and that alert rules exist for the things that actually page (node down, disk pressure, cert expiry, target down, Longhorn volume degraded).
 - **External/synthetic monitoring (Uptime Kuma)** — the live `uptime.themartinez.cloud` instance: monitor inventory, check intervals/retries/timeouts tuned per service type, data retention, and the Discord notification wiring. Uptime Kuma's Prometheus `/metrics` feed is what backs the Grafana `uptime.json` dashboard, so I keep both ends in sync.
+- **Squad Discord status updates** — posting regular operational updates to the team Discord channel during work sessions (rollout progress, incident status, "all green" confirmations). The webhook is **never hardcoded**: it is read at runtime from 1Password (`op read op://$OP_VAULT/discord/webhook`, vault default `homelab`), so it stays out of git and rotates in one place. Keep updates signal-heavy — the same anti-noise discipline I apply to alerts applies here.
 - **The monitoring map staying current** — when MetalLB VIPs, DNS architecture, or endpoints change, the monitors and dashboards change with them.
 
 ## How I Work
@@ -26,13 +27,18 @@
 - **Uptime Kuma app is in Git (`apps/uptime/`), but its monitor inventory is runtime MariaDB state.** I manage monitors against the running instance via its socket.io API (username/password — the `uk1_` API key only authenticates `/metrics`). API credentials come from the existing 1Password `uptime` item (`op read op://$OP_VAULT/uptime/UPTIME_USERNAME|UPTIME_PASSWORD`) at runtime — never a committed secret or a new key. Changes there are additive and reversible; I keep a written record of the monitor inventory and settings so a database loss is recoverable.
 - I run `scripts/validate.sh` before handing off any `platform/monitoring/` change.
 
-### Uptime Kuma API tooling (ad-hoc by team decision — not committed)
+### Uptime Kuma API tooling
 
-The API tooling stays **ad-hoc** — assembled per task, not committed. If a repeatable process emerges, formalize it as a **skill** + repo tool later. Reproducible recipe:
+The monitor **retry/stagger policy is formalized** as `scripts/tune-uptime-monitors.py`
+(idempotent; the reviewable source of truth that re-applies after a DB restore).
+Run it via a `kubectl -n uptime port-forward svc/uptime-svc 3001:80` and it reads
+creds from 1Password. Ad-hoc *exploration* tooling (one-off queries, new monitor
+creation) stays assembled per task — only promote a recipe to a committed tool
+when it becomes a repeatable policy. Reproducible recipe for ad-hoc work:
 
-- **Creds at runtime from 1Password** (never committed): `op read op://$OP_VAULT/uptime/UPTIME_USERNAME` and `…/UPTIME_PASSWORD` (vault default `homelab`). URL `https://uptime.themartinez.cloud`.
+- **Creds at runtime from 1Password** (never committed): `op read op://$OP_VAULT/uptime/UPTIME_USERNAME` and `…/UPTIME_PASSWORD` (vault default `homelab`).
 - **Library:** `uptime-kuma-api` (Python) in a throwaway venv — macOS is PEP-668 externally-managed, so a venv is mandatory.
-- **Connect:** `UptimeKumaApi(URL, timeout=120)` then `.login(user, pass)`; login is slow behind the proxy — use a small retry loop (default timeout fails).
+- **Connect via port-forward, not the public URL.** Uptime Kuma is **v2.4.0**; the `uptime-kuma-api` library targets ≤1.23, and its socket.io handshake **times out through the Traefik ingress** (`https://uptime.themartinez.cloud` returns a 302 + TLS/websocket that the client can't complete). Port-forward the ClusterIP service and connect to localhost: `kubectl -n uptime port-forward svc/uptime-svc 3001:80` then `UptimeKumaApi("http://localhost:3001", timeout=30)` + `.login(user, pass)`.
 - **`add_monitor` quirk:** it calls `_build_monitor_data` with a FIXED signature; backup-only fields (`id`, `tags`, `pathName`, `childrenIDs`, `weight`, …) raise `TypeError`. Filter kwargs to `inspect.signature(api._build_monitor_data).parameters`; `type` MUST be a `MonitorType` enum, not a string. Apply tags/notifications in a second call.
 - **`edit_monitor`** is fetch-merge-save (partial updates safe). **`set_settings`** REPLACES all settings — read `get_settings()` first and pass current values back, overriding only what changes (e.g. `keepDataPeriodDays`).
 - **Mins:** `interval`/`retryInterval` ≥ 20, `maxretries` ≥ 0. Gamedig Minecraft Bedrock key is `mbe`. Live server is **v2.4.0** (library targets ≤1.23 — verify anything exotic).

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -9,6 +9,7 @@ How to decide who handles what.
 | GitOps control plane & architecture | Ripley | ArgoCD root/appset/projects, sync waves, promotion gates, app-of-apps structure |
 | Kubernetes apps & platform stacks | Dallas | `apps/<app>` Kustomize bases, `platform/<stack>` Helm values, HA (probes/PDB/HPA/spread), Traefik ingress |
 | Observability & monitoring | Ash | `platform/monitoring` (Prometheus/Grafana/Alertmanager/exporters), ServiceMonitors/PrometheusRules/dashboards, scrape & retention tuning, Uptime Kuma synthetic checks, sizing of the monitoring stack |
+| Discord status updates | Ash | Posting regular operational updates to the team Discord during work sessions; webhook read at runtime from 1Password (`op://homelab/discord/webhook`), never hardcoded |
 | Node provisioning & Ansible | Parker | Ansible roles, `provision.yml`/`adopt.yml`, k3s server/agent, storage, `bootstrap/` |
 | Secrets, TLS & security | Bishop | `secrets/templates` `op://` refs, `sync-secrets.sh`, cert-manager/TLS, `validate.sh` guards |
 | Documentation | Lambert | `docs/`, runbooks, `README.md`, keeping docs accurate for open-source learners |

--- a/ansible/roles/base/defaults/main.yml
+++ b/ansible/roles/base/defaults/main.yml
@@ -84,6 +84,13 @@ base_network_watchdog_state_dir: /var/lib/homelab-network-watchdog
 # Optional Raspberry Pi hardware watchdog defense-in-depth for kernel hangs.
 # Operator opt-in only; this writes systemd watchdog config and reports that a
 # reboot/manual rollout is required for complete activation.
+#
+# WARNING: the Raspberry Pi BCM2835 hardware watchdog has a ~15s MAXIMUM timeout.
+# RuntimeWatchdogSec must stay under it (systemd pets at half the interval), or
+# the watchdog will hard-reset the node under I/O load before systemd can pet it.
+# A value of 30s caused a confirmed hard reset on rpi004 during a heavy apply
+# (2026-06-28); keep this <= 14s. Activation is also intentionally separate from
+# the other resilience gates and stays off during routine node rollouts.
 base_hardware_watchdog_apply: false
-base_hardware_watchdog_runtime_sec: 30s
+base_hardware_watchdog_runtime_sec: 14s
 base_hardware_watchdog_reboot_sec: 10min

--- a/ansible/roles/base/templates/homelab-network-watchdog.sh.j2
+++ b/ansible/roles/base/templates/homelab-network-watchdog.sh.j2
@@ -15,6 +15,7 @@ REBOOT_AFTER="{{ base_network_watchdog_reboot_after_failures }}"
 REBOOT_MAX="{{ base_network_watchdog_reboot_max_per_window }}"
 REBOOT_WINDOW="{{ base_network_watchdog_reboot_window_seconds }}"
 STATE_DIR="{{ base_network_watchdog_state_dir }}"
+{% raw %}
 FAIL_FILE="${STATE_DIR}/fail-count"
 REBOOT_FILE="${STATE_DIR}/reboot-history"
 
@@ -89,3 +90,4 @@ recent_reboots+=("${now}")
 printf '%s\n' "${recent_reboots[@]}" > "${REBOOT_FILE}"
 logger -t homelab-network-watchdog "gateway still unreachable after ${fail_count} checks; requesting controlled reboot"
 systemctl reboot --message="homelab-network-watchdog: gateway ${GATEWAY} unreachable after ${fail_count} checks"
+{% endraw %}

--- a/scripts/tune-uptime-monitors.py
+++ b/scripts/tune-uptime-monitors.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Tune Uptime Kuma monitor retry/interval policy (idempotent).
+
+Uptime Kuma stores monitor configuration in its MariaDB database, not in git, so
+this script is the reviewable source of truth for the homelab monitor policy. It
+re-applies the policy after a database restore or a fresh setup.
+
+Why this policy:
+  * Fewer false outages / less Discord noise — monitors need several consecutive
+    failed checks (``maxretries``) before they are reported DOWN, so a transient
+    blip no longer pages.
+  * Gentler on probed services — the normal check ``interval`` is *staggered*
+    per monitor so the checks do not all fire in the same instant (a
+    thundering-herd on the LAN/services). Uptime Kuma exposes only a per-monitor
+    period, so a slightly different period per monitor makes them drift apart.
+  * Slower, calmer retries — ``retryInterval`` is widened so a struggling
+    service is not hammered while it is being re-checked.
+
+Tiers are detected from the existing normal interval:
+  * Internal/LAN monitors (interval <= 120s): maxretries=4, retryInterval=90,
+    staggered interval starting at 60s (60, 61, 62, ... by monitor id order).
+  * External internet canaries (interval > 120s, e.g. Google/Cloudflare): these
+    hit third-party sites, so keep the gentle ~5-minute cadence — maxretries=3,
+    retryInterval=90, staggered interval starting at 300s (300, 304, 308, ...).
+GROUP monitors are organizational containers and are never probed, so they are
+skipped.
+
+Usage:
+  # Port-forward the in-cluster service first (the app is ClusterIP-only):
+  kubectl -n uptime port-forward svc/uptime-svc 3001:80 &
+
+  # Credentials: either export UK_USER / UK_PASS, or let the script read them
+  # from 1Password (op must be signed in or OP_SERVICE_ACCOUNT_TOKEN set):
+  scripts/tune-uptime-monitors.py            # apply
+  scripts/tune-uptime-monitors.py --dry-run  # show planned changes only
+
+Environment:
+  UPTIME_KUMA_URL   Base URL of the Uptime Kuma instance (default
+                    http://localhost:3001 — i.e. the port-forward above).
+  UK_USER / UK_PASS Admin credentials. If unset, read from 1Password item
+                    "uptime" (fields UPTIME_USERNAME / UPTIME_PASSWORD) in the
+                    vault named by OP_VAULT (default: homelab).
+
+Requires: pip install uptime-kuma-api
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+# Tier policy. Keep these in one place so review is trivial.
+INTERNAL_MAXRETRIES = 4
+INTERNAL_INTERVAL_BASE = 60   # seconds; staggered by +1s per monitor
+EXTERNAL_MAXRETRIES = 3
+EXTERNAL_INTERVAL_BASE = 300  # seconds; staggered by +4s per monitor
+EXTERNAL_INTERVAL_STEP = 4
+RETRY_INTERVAL = 90           # seconds between re-checks while retrying
+INTERNAL_TIER_MAX_INTERVAL = 120  # monitors at/under this are "internal"
+
+
+def _op_read(ref: str) -> str:
+    """Resolve a 1Password secret reference with the op CLI."""
+    return subprocess.run(
+        ["op", "read", ref],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _credentials() -> tuple[str, str]:
+    user = os.environ.get("UK_USER")
+    password = os.environ.get("UK_PASS")
+    if user and password:
+        return user, password
+    vault = os.environ.get("OP_VAULT", "homelab")
+    try:
+        return (
+            _op_read(f"op://{vault}/uptime/UPTIME_USERNAME"),
+            _op_read(f"op://{vault}/uptime/UPTIME_PASSWORD"),
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        sys.exit(
+            "Could not obtain credentials. Set UK_USER/UK_PASS or sign in to "
+            f"1Password (op). Underlying error: {exc}"
+        )
+
+
+def _plan(monitors: list[dict]) -> dict[int, dict]:
+    """Build the desired settings per monitor id (deterministic, id-ordered)."""
+    probes = sorted(
+        (m for m in monitors if str(m.get("type")) != "MonitorType.GROUP"),
+        key=lambda m: m["id"],
+    )
+    internal = [m for m in probes if (m.get("interval") or 0) <= INTERNAL_TIER_MAX_INTERVAL]
+    external = [m for m in probes if (m.get("interval") or 0) > INTERNAL_TIER_MAX_INTERVAL]
+    plan: dict[int, dict] = {}
+    for rank, m in enumerate(internal):
+        plan[m["id"]] = {
+            "maxretries": INTERNAL_MAXRETRIES,
+            "retryInterval": RETRY_INTERVAL,
+            "interval": INTERNAL_INTERVAL_BASE + rank,
+        }
+    for rank, m in enumerate(external):
+        plan[m["id"]] = {
+            "maxretries": EXTERNAL_MAXRETRIES,
+            "retryInterval": RETRY_INTERVAL,
+            "interval": EXTERNAL_INTERVAL_BASE + rank * EXTERNAL_INTERVAL_STEP,
+        }
+    return plan
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Tune Uptime Kuma monitor retry/stagger policy.")
+    parser.add_argument("--dry-run", action="store_true", help="Show planned changes; apply nothing.")
+    args = parser.parse_args()
+
+    try:
+        from uptime_kuma_api import UptimeKumaApi
+    except ImportError:
+        sys.exit("uptime-kuma-api is required: pip install uptime-kuma-api")
+
+    url = os.environ.get("UPTIME_KUMA_URL", "http://localhost:3001")
+    user, password = _credentials()
+
+    api = UptimeKumaApi(url, timeout=40)
+    try:
+        api.login(user, password)
+        monitors = api.get_monitors()
+        plan = _plan(monitors)
+        by_id = {m["id"]: m for m in monitors}
+
+        changed = skipped = errors = 0
+        for mid, desired in sorted(plan.items()):
+            current = by_id[mid]
+            if all(current.get(k) == v for k, v in desired.items()):
+                skipped += 1
+                continue
+            name = (current.get("name") or "")[:28]
+            summary = (
+                f"maxretries={desired['maxretries']} "
+                f"interval={desired['interval']} "
+                f"retryInterval={desired['retryInterval']}"
+            )
+            if args.dry_run:
+                print(f"  WOULD UPDATE id={mid:>3} {name:<28} -> {summary}")
+                changed += 1
+                continue
+            try:
+                api.edit_monitor(mid, **desired)
+                print(f"  updated id={mid:>3} {name:<28} -> {summary}")
+                changed += 1
+            except Exception as exc:  # noqa: BLE001 - report and continue
+                print(f"  ERROR  id={mid:>3} {name:<28}: {exc}", file=sys.stderr)
+                errors += 1
+
+        verb = "would change" if args.dry_run else "changed"
+        print(f"\n{verb}={changed} unchanged={skipped} errors={errors} "
+              f"(skipped GROUP monitors are organizational, never probed)")
+        return 1 if errors else 0
+    finally:
+        api.disconnect()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Operational quality-of-life sprint: tune Uptime Kuma to stop the Discord false-alarm noise, give the squad a 1Password-sourced Discord update role, and fix two latent bugs found while rolling out the #62/#75 node-resilience Ansible to all four nodes.

## 1. Uptime Kuma tuning — `scripts/tune-uptime-monitors.py` (#54)
Kuma was calling services down after just 1–2 failed checks and probing them in synchronized bursts → noisy Discord, hiding real issues. Monitor config lives in MariaDB (not git), so this idempotent script is the **reviewable source of truth** and re-applies after a DB restore.
- **More tries before "down":** maxretries **2 → 4** (internal/LAN), **1 → 3** (external internet canaries).
- **Staggered check windows:** each monitor gets a slightly different period (internal **60–76s**, external **300–316s**) so checks drift apart instead of all firing at once — gentler on the LAN/services (addresses "hitting our services too hard").
- **Calmer retries:** retryInterval **60 → 90s**.
- GROUP monitors skipped (never probed). Reads admin creds from 1Password at runtime; `--dry-run` supported.
- **Already applied live** to all 22 probe monitors (0 errors); script `--dry-run` now reports 0 changes (idempotent).
- Note: connect via `kubectl -n uptime port-forward svc/uptime-svc 3001:80` — the `uptime-kuma-api` socket.io handshake times out through the Traefik ingress against Kuma v2.x.

## 2. Squad Discord update role
Assigned **Ash** (Observability — already owns Kuma + its Discord wiring) the role of posting regular operational updates to Discord during work sessions. The webhook is read at runtime from **1Password** (`op://homelab/discord/webhook`) — never hardcoded — matching the push-secret model. Verified end-to-end (HTTP 204 via the op-resolved webhook). `routing.md` + Ash's charter updated.

## 3. Ansible node-resilience bug fixes (#73) — found during rollout
The #62/#75 gated rollout was applied **live to all four nodes** (static IPs, dhcpcd persistence, software network watchdog, kubelet reservations). Two latent bugs surfaced and are fixed here:
- **Network-watchdog template wouldn't render:** bash `${#recent_reboots[@]}` collides with Jinja's `{#` comment delimiter → wrapped the shell body in `{% raw %}`. Verified rendering to valid bash on all nodes (`bash -n` clean).
- **Hardware-watchdog timeout too high:** `RuntimeWatchdogSec=30s` exceeds the Pi BCM2835 **~15s hardware max**, which hard-reset a node under apt I/O load. Lowered to **14s** + documented the cap; hardware watchdog stays **off** during routine rollouts (the software network watchdog covers the actual dhcpcd/lease-loss incident).

## Verification
- `scripts/validate.sh` passes; leak gate clean; no literal secrets/webhooks in changed files.
- Node rollout verified: all 4 nodes Ready, static IPs active (`noprefixroute`), kubelet reservations live (alloc < capacity), software watchdog active, DNS `.53`+`.110` resolving, Longhorn healthy.
- Kuma tuning verified live + idempotent; Discord post verified (204).

## Not in this PR (operational / runtime)
- The node rollout itself (live Ansible apply) and the Kuma monitor changes (runtime DB) are operational actions; this PR carries the **code/policy** behind them for review.
