### PR TITLE
feat: earmark heavy memory workloads to the 8GB node rpi001 (#77)

### DIFF
--- a/ansible/roles/k3s_server/defaults/main.yml
+++ b/ansible/roles/k3s_server/defaults/main.yml
@@ -27,3 +27,11 @@ k3s_server_scheduler_args:
 k3s_prefer_bundled_bin: true
 k3s_install_helm: true
 k3s_helm_path: /usr/local/bin/helm
+# Node labels applied via the k3s `node-label` config key. rpi001 was upgraded
+# from 4GB to 8GB RAM, so it is earmarked to host the cluster's largest memory
+# tenants (Prometheus, Grafana, ArgoCD controller/repo-server) via per-workload
+# tolerations + nodeAffinity. The legacy control-plane NoSchedule taint (added
+# when rpi001 was 4GB) stays in place so the node is reserved for these earmarked
+# workloads rather than open to everything.
+k3s_server_node_labels:
+  - "node.themartinez.cloud/memory-tier=large"

--- a/ansible/roles/k3s_server/tasks/main.yml
+++ b/ansible/roles/k3s_server/tasks/main.yml
@@ -34,6 +34,12 @@
       {% for arg in (k3s_common_kubelet_args + k3s_node_resilience_kubelet_args) %}
         - {{ arg | to_json }}
       {% endfor %}
+      {% if k3s_server_node_labels | default([]) | length > 0 %}
+      node-label:
+      {% for label in k3s_server_node_labels %}
+        - {{ label | to_json }}
+      {% endfor %}
+      {% endif %}
       kube-proxy-arg:
       {% for arg in k3s_common_kube_proxy_args %}
         - {{ arg | to_json }}

--- a/platform/argocd/helm-values.yaml
+++ b/platform/argocd/helm-values.yaml
@@ -8,10 +8,46 @@ redis-ha:
   enabled: false
 controller:
   replicas: 1
+  # Earmark the application-controller (the heaviest ArgoCD component — it holds
+  # all Application state in memory) to the 8GB node rpi001, off the 4GB workers.
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node.themartinez.cloud/memory-tier
+                operator: In
+                values: ["large"]
 server:
   replicas: 1
 repoServer:
   replicas: 1
+  # Earmark the repo-server (renders manifests during sync — memory-hungry) to the
+  # 8GB node rpi001 alongside the controller, off the 4GB workers.
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node.themartinez.cloud/memory-tier
+                operator: In
+                values: ["large"]
 applicationSet:
   replicas: 1
 # Dex is unused (no SSO); the raw install's argocd-dex-server is orphaned at

--- a/platform/monitoring/helm-values.yaml
+++ b/platform/monitoring/helm-values.yaml
@@ -98,6 +98,26 @@ prometheus:
       limits:
         memory: 1536Mi
         cpu: 500m
+    # Earmark Prometheus (the cluster's largest memory tenant ~1.5Gi) to the 8GB
+    # node rpi001 so it stays off the memory-constrained 4GB workers. The
+    # toleration permits the control-plane taint; the preferred nodeAffinity pulls
+    # it to the large node but falls back to a worker if rpi001 is unavailable.
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+                - key: node.themartinez.cloud/memory-tier
+                  operator: In
+                  values: ["large"]
     # PVC configuration
     storageSpec:
       volumeClaimTemplate:
@@ -197,16 +217,26 @@ grafana:
     accessModes:
       - ReadWriteOnce
     storageClassName: longhorn
-  # Pod scheduling - avoid co-locating with Prometheus
+  # Earmark Grafana to the 8GB node rpi001 alongside Prometheus. The large node
+  # has room for both; this vacates a memory-constrained 4GB worker. Replaces the
+  # previous anti-affinity that deliberately spread Grafana away from Prometheus
+  # across the 4GB workers — co-locating them on the 8GB node is now desired.
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
   affinity:
-    podAntiAffinity:
+    nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: prometheus
-            topologyKey: kubernetes.io/hostname
+          preference:
+            matchExpressions:
+              - key: node.themartinez.cloud/memory-tier
+                operator: In
+                values: ["large"]
   # ServiceMonitor label and job relabel
   serviceMonitor:
     labels:
@@ -403,6 +433,25 @@ kube-state-metrics:
     limits:
       memory: 128Mi
       cpu: 100m
+  # Earmark kube-state-metrics to the 8GB node rpi001 (it was crash-looping under
+  # memory pressure on the 4GB workers). Small, but co-locating the monitoring
+  # stack on the large node keeps it stable.
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node.themartinez.cloud/memory-tier
+                operator: In
+                values: ["large"]
 
 crds:
   # CRDs for kube-prometheus-stack are managed out-of-band (server-side apply,


### PR DESCRIPTION
Addresses the rpi002/003/004 memory saturation + cascading crash loops from #77 — and identifies the real root cause.

## Root cause
Live node usage shows the imbalance clearly:

| Node | CPU | **Memory** | Verdict |
|------|-----|--------|---------|
| rpi001 (8GB) | 9% | **46%** | idle — ~5GB free |
| rpi002 (4GB) | 37% | **98%** | saturated |
| rpi003 (4GB) | 19% | **119%** | over capacity |
| rpi004 (4GB) | 26% | **108%** | over capacity |

The 4GB workers are memory-saturated while the **8GB rpi001 sits idle** — because a legacy `NoSchedule` control-plane taint (added when rpi001 was a 4GB Pi, since **upgraded to 8GB**) walls normal workloads off the largest node. That memory pressure is what OOM/probe-kills the crash-loopers (Grafana, kube-state-metrics, Traefik, cert-manager-webhook, MetalLB speakers). The descheduler can't help because there's nowhere good to move pods *to*.

## Fix — earmark, don't open up
Rather than removing the taint (which would open the control plane to everything), this earmarks only the heaviest memory tenants to rpi001 via a per-workload **toleration + preferred nodeAffinity** (`node.themartinez.cloud/memory-tier=large`):
- **Prometheus** (~1.5Gi), **Grafana**, **kube-state-metrics**
- **ArgoCD** application-controller + repo-server

`preferred` (not `required`) keeps them resilient — they strongly prefer rpi001 but fall back to a worker if it's unavailable. This moves **~3Gi of demand off the 4GB workers**, the primary relief for the memory-driven crash loops. Grafana's old anti-Prometheus affinity is replaced (the 8GB node has room for both).

## Verification
- `helm template` confirms all five workloads render the control-plane/master tolerations + the `memory-tier=large` nodeAffinity.
- rpi001 labeled `node.themartinez.cloud/memory-tier=large` (live + added declaratively to Ansible `k3s_server`).
- `scripts/validate.sh` passes.

## Apply (after merge)
Manually sync `monitoring` then `argocd`; the earmarked pods reschedule onto rpi001. The control-plane taint stays in place.

## Follow-ups (remaining #77 scope)
- Descheduler reconcile (git helm-values uses the dead legacy `strategies:` format; live runs chart-default `profiles`) + re-add Longhorn/system namespace protections.
- Defense-in-depth probe hardening for the MetalLB speaker (same fragile probe #75 fixed for the controller) and other repeat crash-loopers.
