### PR TITLE
perf(shlink): 2->1 replica (~-264Mi) — capacity diet #83 item 1

### DIFF
--- a/apps/shlink/horizontalpodautoscaler.yml
+++ b/apps/shlink/horizontalpodautoscaler.yml
@@ -10,8 +10,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: shlink-shortener
-  minReplicas: 2
-  maxReplicas: 3
+  minReplicas: 1
+  maxReplicas: 2
   metrics:
     - type: Resource
       resource:


### PR DESCRIPTION
Part of #83 (capacity diet, item 1 of 4).

## Change
- `apps/shlink/horizontalpodautoscaler.yml`: minReplicas 2 to 1, maxReplicas 3 to 2.

shlink-shortener ran 2 replicas (204Mi+324Mi). A personal URL shortener does not need 2 steady-state. HPA still bursts to 2 under CPU; PDB minAvailable:1, probes, resources unchanged.

## Impact
- ~-264Mi steady-state. Reversible (bump min back to 2). HA preserved via PDB + burst headroom.

## Validation
- `scripts/validate.sh` passed (kustomize build, helm template, secret scan, prune/selfHeal guard, appset deletion safety).
- Manual ArgoCD sync after merge; observe shlink + node mem.
