### PR TITLE
perf(longhorn): replicas 3->2 + lower IM CPU — capacity diet #83 item 2

### DIFF
--- a/apps/shlink/horizontalpodautoscaler.yml
+++ b/apps/shlink/horizontalpodautoscaler.yml
@@ -10,8 +10,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: shlink-shortener
-  minReplicas: 2
-  maxReplicas: 3
+  minReplicas: 1
+  maxReplicas: 2
   metrics:
     - type: Resource
       resource:

--- a/platform/longhorn/helm-values.yaml
+++ b/platform/longhorn/helm-values.yaml
@@ -1,5 +1,7 @@
 # LONGHORN ADOPTION WARNING — LIVE STORAGE LAYER
-# Do NOT change defaultDataPath, defaultReplicaCount, backup target, or StorageClass during adoption.
+# Do NOT change defaultDataPath, backup target, or StorageClass during adoption.
+# defaultReplicaCount intentionally tuned 3->2 post-adoption (capacity diet #83);
+# affects new volumes only — existing volumes migrate one at a time, watch rebuilds.
 # CRDs are chart-delivered for now and must never be pruned.
 # Freeze chart version to live (platform-apps.yml currently pins 1.10.0; confirm with helm list -n longhorn-system).
 # Do not upgrade while adopting the live release.
@@ -20,15 +22,24 @@ defaultSettings:
   # D-state, DNS UDP recv-queue backing up). Cross-node reads on a small LAN are
   # cheap, so locality is not worth the rebuild churn.
   defaultDataLocality: disabled
-  defaultReplicaCount: "3" # cluster-specific: LONGHORN_REPLICACOUNT
+  # 2 (down from 3): memory diet. Hard zone anti-affinity is per-node, so 2
+  # replicas still survive a single-node loss; 3-replica gave no extra zone
+  # safety on a 4-node cluster but cost ~1/3 more replica RAM/disk + double the
+  # rebuild I/O after a reschedule. Applies to NEW volumes only — existing
+  # volumes keep their numberOfReplicas until migrated 3->2 one at a time.
+  defaultReplicaCount: "2" # cluster-specific: LONGHORN_REPLICACOUNT
   disableSchedulingOnCordonedNode: true
   # 30s (max allowed), up from the 16s we ran before: on contended Pi disks a
   # replica can be slow-but-alive mid-rebuild. A short timeout marks it failed and
   # triggers yet another rebuild, feeding the I/O storm. The Longhorn-permitted
   # range is 8-30s; use the max to tolerate slow rebuilds without flapping.
   engineReplicaTimeout: "30"
-  guaranteedEngineManagerCPU: 200m
-  guaranteedReplicaManagerCPU: 200m
+  # 8% (down from the 12% chart default): the old guaranteedEngineManagerCPU /
+  # guaranteedReplicaManagerCPU keys were merged into this single setting in
+  # Longhorn 1.x and were silently ignored (Setting showed applied:false). 8% of
+  # 4 cores ~= 320m reserved/node frees ~160m/node for latency-sensitive pods
+  # while keeping instance-managers guaranteed. Raise back to 12 if I/O suffers.
+  guaranteedInstanceManagerCPU: "8"
   # 120s, up from the 30s default: large snapshot chains (e.g. prometheus) take
   # longer than 30s to sync over the LAN to a rebuilding replica on slow Pi disks.
   # Too low a timeout aborts the file sync and restarts the rebuild from scratch.
@@ -76,3 +87,6 @@ persistence:
   # should not request best-effort locality for new PVCs.
   defaultDataLocality: disabled
   reclaimPolicy: Retain
+  # Match defaultSettings.defaultReplicaCount: new PVCs from the longhorn
+  # StorageClass provision with 2 replicas.
+  defaultClassReplicaCount: 2


### PR DESCRIPTION
Part of #83 (capacity diet, item 2 — biggest win). Data-sensitive: manual sync, one volume at a time.

## Backup gate (verified before change)
- 13/13 volumes labeled `recurring-job-group.longhorn.io/default: enabled`
- backuptarget `default` AVAILABLE=true, last backup today, lastSynced ~5m
- recurringjobs: backup-default (daily, retain 10), snapshot-default, filesystem-trim-weekly

## Change (`platform/longhorn/helm-values.yaml`)
- `defaultReplicaCount` 3 to 2 — affects NEW volumes only; 2 replicas + hard per-node anti-affinity still survive 1-node loss.
- `defaultClassReplicaCount: 2` — StorageClass matches.
- `guaranteedInstanceManagerCPU: 8` (was 12% default) — frees ~160m/node; replaces deprecated guaranteedEngine/ReplicaManagerCPU (ignored since 1.x).

## Live migration (operator, post-sync, one at a time)
5 volumes still at 3 replicas (7 already at 2). Per volume: lower replica 3→2 in UI/CR, wait healthy, watch rebuild I/O, then next. Backup verified fresh before each.

## Impact
- Less replica RAM/disk + half rebuild load; ~160m/node CPU freed. Fully reversible (back to 3).

## Validation
- `scripts/validate.sh` passed.
