### PR TITLE
perf(monitoring): -300Mi retention+alertmanager+grafana — #83 item 3

### DIFF
--- a/platform/monitoring/helm-values.yaml
+++ b/platform/monitoring/helm-values.yaml
@@ -32,6 +32,12 @@ prometheusOperator:
   kubeletService:
     enabled: false
 alertmanager:
+  # Disabled for the capacity diet (#83): Uptime Kuma provides external/synthetic
+  # alerting and Prometheus rules below remain visible in the Prometheus UI.
+  # Saves the Alertmanager pod (req 48Mi / limit 128Mi) + its 5Gi PVC. Re-enable
+  # if in-cluster routing/silencing is needed again. alertmanagerSpec retained so
+  # flipping enabled:true restores the prior config.
+  enabled: false
   alertmanagerSpec:
     # Subpath /alertmanager configuration
     externalUrl: http://monitoring.themartinez.cloud/alertmanager/ # cluster-specific: NETWORK_HOSTNAME_SUFFIX
@@ -85,18 +91,19 @@ prometheus:
     # Subpath /prometheus configuration
     externalUrl: http://monitoring.themartinez.cloud/prometheus/ # cluster-specific: NETWORK_HOSTNAME_SUFFIX
     routePrefix: /
-    # Data retention configuration
-    retention: 21d
-    retentionSize: 12GB
+    # Data retention configuration (10d, down from 21d — capacity diet #83)
+    retention: 10d
+    retentionSize: 8GB
     walCompression: true
-    # Resources request and limits - tuned for observed usage (~700Mi+ mem with 21d retention)
-    # Limit kept at 1536Mi to avoid memory pressure on 4GB RPi worker nodes
+    # Resources request and limits - tuned for observed usage (~500Mi mem at 10d
+    # retention, down from ~700Mi+ at 21d). Limit kept generous to avoid OOM on
+    # query spikes while freeing reservation pressure on the 4GB nodes.
     resources:
       requests:
-        memory: 1024Mi
+        memory: 768Mi
         cpu: 50m
       limits:
-        memory: 1536Mi
+        memory: 1280Mi
         cpu: 500m
     # Earmark Prometheus (the cluster's largest memory tenant ~1.5Gi) to the 8GB
     # node rpi001 so it stays off the memory-constrained 4GB workers. The
@@ -177,13 +184,14 @@ grafana:
   deploymentStrategy:
     type: Recreate
   # No extra plugins; avoids unsupported Angular panels on Grafana 11+
-  # Resources configuration - tuned for observed usage (~280Mi mem, ~42m CPU under active use)
+  # Resources configuration - tuned for observed usage (~280Mi mem, ~42m CPU). One
+  # small Grafana; limit trimmed 1024->512Mi for the capacity diet (#83).
   resources:
     requests:
-      memory: 384Mi
+      memory: 256Mi
       cpu: 150m
     limits:
-      memory: 1024Mi
+      memory: 512Mi
       cpu: 750m
   # Startup probe gives Grafana time to initialize grafana-apiserver on slow RPi
   startupProbe:
@@ -284,6 +292,8 @@ kubeEtcd:
 defaultRules:
   create: true
   rules:
+    # Alertmanager disabled (#83) — suppress its self-monitoring rule.
+    alertmanager: false
     etcd: false
     k8s: false
     kubeApiserverAvailability: false

--- a/platform/monitoring/ingress.yml
+++ b/platform/monitoring/ingress.yml
@@ -15,13 +15,6 @@ spec:
       middlewares:
         - name: stripprefix
     - kind: Rule
-      match: Host(`monitoring.themartinez.cloud`) && PathPrefix(`/alertmanager`)
-      services:
-        - name: monitoring-kube-prometheus-alertmanager
-          port: 9093
-      middlewares:
-        - name: stripprefix
-    - kind: Rule
       match: Host(`monitoring.themartinez.cloud`) && PathPrefix(`/grafana`)
       services:
         - name: monitoring-grafana

--- a/platform/monitoring/prefix-middleware.yml
+++ b/platform/monitoring/prefix-middleware.yml
@@ -6,5 +6,4 @@ spec:
   stripPrefix:
     prefixes:
       - "/prometheus"
-      - "/alertmanager"
     forceSlash: false


### PR DESCRIPTION
Part of #83 (capacity diet, item 3, ~-300Mi).

## Changes (`platform/monitoring/`)
- **Drop Alertmanager** (`alertmanager.enabled: false`) — Uptime Kuma covers external/synthetic alerting. Removes the AM pod (req48/limit128Mi) + 5Gi PVC. Pruned its IngressRoute, /alertmanager strip-prefix, and the `AlertmanagerDown` defaultRule. Prometheus rules stay visible in the UI.
- **Retention** 21d→10d, retentionSize 12→8GB. Prometheus mem req 1024→768Mi, limit 1536→1280Mi (~500Mi observed at 10d).
- **Grafana** one replica; limit 1024→512Mi.

## Impact
~-300Mi steady-state + reduced reservation on 4GB nodes. Fully reversible. Node-resilience + MetalLB PrometheusRules retained.

## Validation
- `scripts/validate.sh` passed. No docs referenced 21d/alertmanager.
- VictoriaMetrics swap (~-600Mi) tracked separately as a spike, not in this PR.
