### PR TITLE
perf(argocd): disable unused notifications controller — #83 item 4

### DIFF
--- a/platform/argocd/helm-values.yaml
+++ b/platform/argocd/helm-values.yaml
@@ -55,6 +55,13 @@ applicationSet:
 dex:
   enabled: false
 
+# Notifications controller is unused: cluster status updates are posted via a
+# 1Password-sourced Discord webhook from a workstation script, not ArgoCD
+# triggers/templates. Disable the controller to reclaim its pod (~27Mi live).
+# Re-enable if in-cluster notification routing is ever wired up. (#83)
+notifications:
+  enabled: false
+
 # Pin redis to the exact live image so adoption does not bump the cache version
 # or change the registry host (live runs public.ecr.aws/.../redis:7.2.7-alpine).
 redis:


### PR DESCRIPTION
Part of #83 (item 4). Disable argocd-notifications-controller (~-27Mi): unused — Discord posts via webhook script, not ArgoCD triggers. dex+redis-ha already off; controllers stay 1 replica. Reversible. validate.sh passed.