### PR TITLE
fix(metallb): speaker tolerant probes (mirror #75 controller) (#77)

### DIFF
--- a/platform/metallb/helm-values.yaml
+++ b/platform/metallb/helm-values.yaml
@@ -71,6 +71,23 @@ speaker:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
       effect: NoSchedule
+  # Tolerant probes mirror the controller fix (#75): on a memory/CPU-saturated Pi
+  # the default fast probe killed MetalLB and dropped the DNS VIP. Give the speaker
+  # the same slack so a slow /metrics can't self-destruct VIP advertisement (#77).
+  livenessProbe:
+    enabled: true
+    failureThreshold: 6
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    successThreshold: 1
+    timeoutSeconds: 5
+  readinessProbe:
+    enabled: true
+    failureThreshold: 6
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    successThreshold: 1
+    timeoutSeconds: 5
   resources:
     requests:
       cpu: 25m


### PR DESCRIPTION
Carry-over from #77. #75 hardened the MetalLB *controller* probe; mirror it on the *speaker* DaemonSet (period 15s, timeout 5s, failureThreshold 6) so a slow /metrics on a saturated Pi can't kill the speaker and drop the DNS VIP. helm template 0.15.2 confirms probes apply. validate.sh passed.