### PR TITLE
feat(gitops): promote changedetection to gate-3 auto-sync (#46)

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -26,3 +26,15 @@ Continuity: Agent history updated. Credentials rotation required before next pro
 ## Sprint 1 (CI/HA Baseline) — Completion Note (2026-06-26)
 
 **PR #55 merged.** Security findings documented. Credentials rotation P1 for next session. validator.sh false-positive fix (issue #32) completed; `.copilot/` and `.squad/` added to path-skip.
+
+
+---
+
+### 2026-06-29T10:28:25Z — Issue Closure Verification Session (Cross-Agent Coordination)
+
+**Session:** Verified closure of triage-flagged issues  
+**Role:** Security/Secrets verification
+
+- Re-verified & closed #67 with concrete evidence (sync-secrets.sh --verify/--reconcile flags, credential rotation runbook + docs)
+- Read-only verification only (gh-issue-API); no working-tree mutations
+- Coordination: 5-agent parallel triage

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -41,3 +41,16 @@ Coordination point: also owns `.env.sample` rewrite decision (decision #4, P1 �
 ## 2026-06-28T21:10:50-04:00 — Observability implementation
 
 Cross-agent handoff recorded by Scribe for Brandon Martinez. Dallas fixed kubelet Endpoints to node IPs `192.168.52.110-113` in `apps+platform/kube-system/metrics-service.yml` and enabled the MetalLB ServiceMonitor. Ash removed 6 dead Grafana dashboards and entries, added lean dashboards for node-exporter 13978, cluster 15757, CoreDNS 5926, Longhorn 13032, and cert-manager 20842 using datasource `${DS_PROMETHEUS}`, added Longhorn/cert-manager ServiceMonitors (`release: monitoring`), and wired kustomization. Ripley is reviewing. Edit-only; Brandon owns commits and `scripts/validate.sh`.
+
+
+---
+
+### 2026-06-29T10:28:25Z — Issue Closure Verification Session (Cross-Agent Coordination)
+
+**Session:** Verified closure of triage-flagged issues  
+**Role:** GitOps/K8s infrastructure verification
+
+- Re-verified & closed #65, #71, #73, #40 with concrete evidence (preserveResourcesOnDeletion guard, backup script, MetalLB HA commits, obsolete probes)
+- Read-only verification only (gh-issue-API); no working-tree mutations
+- Coordination: 5-agent parallel triage; backup-verification gate (decision #10) now standing rule
+2026-06-29T11:05:06-04:00 Promoted changedetection to gate-3 explicit Application (stateful, auto-sync, prune/selfHeal OFF) in apps-appset.yml for #46.

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -26,3 +26,16 @@ Continuity: Agent history updated. Docs delivery complete; ready for next sessio
 ## Sprint 1 (CI/HA Baseline) — Completion Note (2026-06-26)
 
 **PR #55 merged.** Documentation complete: `docs/reviews/` + `docs/hardware-inventory.md` shipped (security-redacted, privacy audit: GREEN). .env.sample rewrite coordinated (issue #47); bootstrap.md ServerSideApply final step documented (issue #47). Review findings consolidated; 45 follow-ups tracked in decisions.md. Ready for next session hardening sprint.
+
+
+---
+
+### 2026-06-29T10:28:25Z — Issue Closure Verification Session (Cross-Agent Coordination)
+
+**Session:** Verified closure of triage-flagged issues  
+**Role:** Documentation verification
+
+- Re-verified & closed #69 with concrete evidence (ArgoCD out-of-sync + disaster-recovery runbooks, both substantive)
+- Read-only verification only (gh-issue-API); no working-tree mutations
+- Coordination: 5-agent parallel triage
+2026-06-29T11:05:06-04:00 checked gitops.md — no explicit app enumeration, no change needed for #46

--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -35,3 +35,15 @@ Coordination point: storage role path alignment (decision #3, P1) is a hard gate
 ## Sprint 1 (CI/HA Baseline) — Completion Note (2026-06-26)
 
 **PR #55 merged.** Hardware inventory extraction complete (rpi001–rpi004 live specs captured). **Critical findings:** rpi003 thermal throttling (78.4 °C, active events) — requires heatsink/fan; rpi001 USB mount undocumented in Ansible. Storage role path-mismatch constraint documented (hard gate: must align `/media/data_ext` + validate before `adopt.yml --allow_disruptive`). Ansible roles OS-conditional cgroup path (Bullseye/Bookworm, issues #50, #51) deployed. Ready for next coordination gate.
+
+
+---
+
+### 2026-06-29T10:28:25Z — Issue Closure Verification Session (Cross-Agent Coordination)
+
+**Session:** Verified closure of triage-flagged issues  
+**Role:** Infrastructure/Ansible verification
+
+- Re-verified & closed #77, #68 with concrete evidence (Minecraft qemu commit, heavy rollout runbook + monitoring alert)
+- Read-only verification only (gh-issue-API); no working-tree mutations
+- Coordination: 5-agent parallel triage

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -53,3 +53,17 @@ Reviewed Ash's comprehensive observability stack assessment and recommendations:
 **Integration:** Findings merged into decisions.md § 11 (Observability Stack Assessment & ServiceMonitor Gaps). Review-only, no manifest changes. Recommendations staged for Coordinator prioritization against capacity diet #83 sync window.
 
 **Continuity:** Ready for next sprint phase (ServiceMonitor deployment sequencing + retention optimization after capacity-diet baseline sync).
+
+
+---
+
+### 2026-06-29T10:28:25Z — Issue Closure Verification Session (Cross-Agent Coordination)
+
+**Session:** Verified closure of triage-flagged issues  
+**Role:** Lead verification + hard gates + #46 follow-up tracking
+
+- Re-verified #45 closed (CRD Applications live, prune safety documented)
+- Held #46 OPEN (changedetection + unbound lack gate-3 auto-sync automation)
+- **Follow-up #46.1 (PRIORITY):** Promote changedetection + unbound to gate-3 auto-sync. This completes #46 verification.
+- Coordination: 5-agent read-only triage; 9 issues closed with concrete evidence; decision #10 (backup-verification gate) now standing rule
+- All orchestration logs written; decisions.md merged from inbox (3 entries); mutable state not committed per pattern

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -285,6 +285,78 @@ Currently deployed:
 
 ---
 
+### 12. Observability Implementation: Dashboards + ServiceMonitors Live (2026-06-29T01-15-08)
+
+**Author:** Ash | **Date:** 2026-06-29 | **Status:** Edit-only pending sync
+
+Executed observability stack implementation (Task 1–5 from decision #11 review):
+
+**TASK 1 — Removed 6 dead dashboards:**
+- Deleted etcd, kubernetes-api-server, kubernetes-controller-manager, kubernetes-kubelet, kubernetes-proxy, kubernetes-scheduler dashboard JSONs
+- Removed corresponding 6 configMapGenerator entries from `platform/monitoring/kustomization.yml`
+- Kept uptime.json/grafana-uptime
+
+**TASK 3–4 — Added 5 lean dashboards + 2 ServiceMonitors:**
+- **Dashboards:** node-exporter (1860, 124 panels ⚠️ heavy but high value for thermal visibility), cluster-overview (15757, 26 panels), coredns (5926, 12 panels), longhorn (13032, 28 panels), cert-manager (20842, 8 panels)
+- All datasource UIDs normalized to `${DS_PROMETHEUS}` in JSON; added configMapGenerator entries with `disableNameSuffixHash: true` + `grafana_dashboard: "true"` label
+- **ServiceMonitors:** longhorn (ns monitoring, app=longhorn-manager, port 9500, 60s) and certmanager (ns monitoring, app.kubernetes.io/name=cert-manager, port 9402, 120s); both labeled `release: monitoring`
+- All resources added to `platform/monitoring/kustomization.yml`
+
+**TASK 5 — Cardinality assessment:**
+- Longhorn 60s, cert-manager 120s, no histogram cardinality adds
+- Node Exporter Full (1860) concern: 124 panels vs. "avoid 100+ panel" guideline. Task explicitly named this ID; RPi thermal/memory visibility ROI justifies risk. Recommend Brandon post-sync evaluation; fallback to ID 13978 (26 panels) if render performance unacceptable
+
+**Status:** Kustomization.yml + JSONs + ServiceMonitors committed (7 files); Dallas independently enabled MetalLB ServiceMonitor; edit-only (no git mutation by Scribe); pending Brandon manual sync.
+
+---
+
+### 13. Triage Verdicts for 27 Open Issues — Recommended Closures & Sprint Plan (2026-06-29T05-18-45)
+
+**Author:** Ripley & team | **Date:** 2026-06-29 | **Status:** Read-only triage; pending Brandon closure execution
+
+Full triage of 27 open issues by Ripley (lead), Dallas (GitOps/K8s), Parker (Infra), Bishop (Security), Ash (capacity/monitoring), Lambert (docs).
+
+**RECOMMEND CLOSE (9 issues):**
+- **#65** — preserveResourcesOnDeletion guard in scripts/validate.sh (check_appset_preserve_policy) + clusters/rpi/apps-appset.yml line 24
+- **#71** — scripts/verify-backup.sh + docs/runbooks/backup-verification.md (both substantive)
+- **#73** — epic COMPLETE: MetalLB HA (3 commits: 3366899, ad07ffe, +1), static node IPs in ansible host_vars, OS net self-healing watchdog templates
+- **#40** — obsolete (dnsdist exec /dev/tcp probes, no dig in image)
+- **#77** — superseded (qemu Minecraft replicas→0 in commit a9055d56; open work in #62 + #82)
+- **#68** — docs/runbooks/heavy-rollouts.md + HomelabNodeHighLoadAverage alert in platform/monitoring/helm-values.yaml line 298
+- **#67** — sync-secrets.sh --verify/--reconcile, commit 6d186ac9da, documented in docs/runbooks/credential-rotation.md + docs/secrets.md
+- **#69** — docs/runbooks/argocd-outofsync.md + docs/runbooks/disaster-recovery.md (both substantive)
+- **#45** — platform/crds/cert-manager v1.19.3 + platform/crds/monitoring kps 82.1.1; Longhorn/MetalLB infeasibility documented in clusters/rpi/platform-apps.yml lines 28–35
+
+**RECOMMEND HOLD OPEN (1 issue):**
+- **#46** — "Only 3 of 5 apps auto-sync." changedetection + unbound still in appset directory generator with no automated block (gate-3 auto-sync promotion pending) — FAILED VERIFICATION; open for follow-up #46.1: promote changedetection + unbound to gate-3 auto-sync to finish
+
+**ENRICH & KEEP (9 issues — feature backlog):**
+- #54, #16, #17, #74, #83, #66, #14, #11, #13, #15, #18, #62, #82, #70, #7, #20, #53 (various P2–P3 features and ongoing work)
+
+**NEEDS-INFO (6 issues — requires clarification):**
+- #62, #82, #70, #7, #20, #53 (clarification/design phase)
+
+**Evidence-Based Verification:**
+- Each owner re-verified evidence concretely before close recommendation
+- All 9 recommended closures cite specific commits, file paths, runbook links, or live cluster evidence
+- #46 held open because only 3 of 5 apps auto-sync enabled (changedetection + unbound lack gate-3 automation) — failing hard verification gate
+
+---
+
+### 14. Promote changedetection to GitOps gate-3 (auto-sync); keep unbound on manual sync (#46)
+
+**Author:** Brandon Martinez (decision) — implemented by Dallas, reviewed/approved by Ripley | **Date:** 2026-06-29 | **Status:** Shipped via branch + PR; #46 closed
+
+changedetection was promoted from ApplicationSet-generated to an explicit gate-3 Application in `clusters/rpi/apps-appset.yml`. Auto-sync is ON (`automated: {}`); prune and selfHeal remain OFF (gates 5/4). The change mirrors the uptime stateful pattern: fixed `replicas: 1`, no HPA, and therefore NO `/spec/replicas` ignoreDifferences.
+
+unbound was intentionally NOT promoted. It remains generator-managed/manual per the DNS-path policy after the 2026-06-26 outage, tracked under DNS-resilience #73/#62/#70.
+
+**Data safety:** changedetection is stateful (Longhorn PVC `changedetection-pvc`, reclaim `Retain`) with fresh backup `2026-06-29T07:00:07Z`. `preserveResourcesOnDeletion: true` ensures the generated → explicit handoff does NOT prune the PVC. `scripts/validate.sh` passed, including prune/selfHeal guard and ApplicationSet deletion-safety guard.
+
+**Outcome:** shipped via branch `feat/changedetection-autosync` + PR; issue #46 closed.
+
+---
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/clusters/rpi/apps-appset.yml
+++ b/clusters/rpi/apps-appset.yml
@@ -40,10 +40,10 @@ spec:
           # `kube-system-metrics` Application (see platform-apps.yml wave 0).
           - path: apps/kube-system
             exclude: true
-          # shlink, uptime, meal-planner, and localproxy have been promoted to
-          # gate 3 (auto-sync). They are defined as explicit Applications below
-          # so syncPolicy.automated can be set per-app. See transition notes in
-          # those Applications.
+          # shlink, uptime, meal-planner, localproxy, and changedetection have
+          # been promoted to gate 3 (auto-sync). They are defined as explicit
+          # Applications below so syncPolicy.automated can be set per-app. See
+          # transition notes in those Applications.
           - path: apps/shlink
             exclude: true
           - path: apps/uptime
@@ -51,6 +51,8 @@ spec:
           - path: apps/meal-planner
             exclude: true
           - path: apps/localproxy
+            exclude: true
+          - path: apps/changedetection
             exclude: true
   template:
     metadata:
@@ -89,11 +91,11 @@ spec:
 ##############################################################################
 # Gate-3 (auto-sync) explicit Applications
 #
-# shlink, uptime, meal-planner, and localproxy are excluded from the
-# ApplicationSet generator above and defined here as explicit Applications so
-# syncPolicy.automated can be set per-app (the shared template cannot carry
-# automated because it applies to ALL apps including stateful ones not ready for
-# it).
+# shlink, uptime, meal-planner, localproxy, and changedetection are excluded
+# from the ApplicationSet generator above and defined here as explicit
+# Applications so syncPolicy.automated can be set per-app (the shared template
+# cannot carry automated because it applies to ALL apps including stateful ones
+# not ready for it).
 #
 # Gate 3 only: automated: {} means auto-sync on drift. prune and selfHeal are
 # deliberately omitted — those are gate 5 and gate 4 respectively and require
@@ -101,14 +103,14 @@ spec:
 #
 # TRANSITION NOTE (for Brandon): when root is synced with this file, the
 # ApplicationSet controller will DELETE the appset-generated `shlink`,
-# `uptime`, `meal-planner`, and `localproxy` Applications (their cluster
-# resources are NOT deleted because prune was OFF on the template). These
-# explicit Applications are then created by root and auto-sync reconciles the
-# running workloads. Recommended sync order:
+# `uptime`, `meal-planner`, `localproxy`, and `changedetection` Applications
+# (their cluster resources are NOT deleted because prune was OFF on the
+# template). These explicit Applications are then created by root and auto-sync
+# reconciles the running workloads. Recommended sync order:
 #   1. Sync `root` (picks up this file — creates these Applications and updates
 #      the ApplicationSet with the new exclusions simultaneously)
-#   2. Verify shlink, uptime, meal-planner, and localproxy Applications appear
-#      Synced / auto-syncing
+#   2. Verify shlink, uptime, meal-planner, localproxy, and changedetection
+#      Applications appear Synced / auto-syncing
 #   There is no manual pre-step needed; ArgoCD handles the Application name
 #   hand-off because the appset deletes its copy and root creates the explicit
 #   copy in the same reconcile pass.
@@ -240,3 +242,35 @@ spec:
       - CreateNamespace=true
       - ServerSideApply=true
       - RespectIgnoreDifferences=true
+---
+##############################################################################
+# Gate-3 stateful promotion
+#
+# changedetection is stateful (Longhorn PVC, Retain reclaim). Auto-sync is safe
+# here ONLY because prune and selfHeal stay OFF — the PVC is never pruned.
+# Fixed replicas: 1 (Recreate), no HPA, so no /spec/replicas ignoreDifferences.
+##############################################################################
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: changedetection
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/managed-by: argocd
+spec:
+  project: apps
+  source:
+    repoURL: https://github.com/brandonmartinez/raspberry-pi-kubernetes-cluster.git
+    targetRevision: main
+    path: apps/changedetection
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: changedetection
+  # Gate 3: auto-sync enabled. prune and selfHeal are NOT enabled (gates 5/4).
+  syncPolicy:
+    automated: {}
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary

Promotes **changedetection** to GitOps **gate-3 (auto-sync)** by converting it from an ApplicationSet-generated Application to an explicit Application in `clusters/rpi/apps-appset.yml`.

- **Auto-sync ON** (`syncPolicy.automated: {}`)
- **prune and selfHeal stay OFF** (gates 5 and 4 — deliberately deferred to separate observed promotions)
- Mirrors the **uptime** stateful pattern: fixed `replicas: 1`, `Recreate`, **no HPA** → **no** `/spec/replicas` `ignoreDifferences` and **no** `RespectIgnoreDifferences`
- changedetection is excluded from the ApplicationSet generator so the explicit Application owns it; enumeration comments updated to match

## Data-safety verification (pre-req for enabling auto-sync)

changedetection is **stateful**, so this was gated on data safety:

- PVC `changedetection-pvc` — storageClass **longhorn**, reclaim **Retain**
- In the default recurring-backup group; **fresh backup completed today** (`lastBackupAt 2026-06-29T07:00:07Z`)
- `preserveResourcesOnDeletion: true` is set on the ApplicationSet, so the generated→explicit handoff **preserves the live PVC** (never pruned)
- Auto-sync is safe **only** because prune/selfHeal remain off — the PVC is never a prune target
- `scripts/validate.sh` passes, including the **prune/selfHeal guard** and the **ApplicationSet deletion-safety guard**; `kustomize build apps/changedetection` succeeds

## unbound — intentionally NOT promoted

`unbound` stays on **manual sync** (generator-managed) per the **DNS-path policy** adopted after the 2026-06-26 outage. DNS resilience is tracked separately under **#73 / #62 / #70**.

## Review

- Production-safety review by **Ripley** (Lead): **APPROVE — safe to ship**

## Rollout note

No manual pre-step: when `root` syncs this file, the ApplicationSet deletes its generated `changedetection` Application (resources preserved) and `root` creates the explicit one in the same reconcile pass. This PR does **not** enable prune/selfHeal, does **not** merge itself, and does **not** sync ArgoCD.

Closes #46