### PR TITLE
backlog: secret-scan skills fix (#97/#96) + service-account rotation runbook (#74)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -178,7 +178,7 @@ for dirpath, dirnames, filenames in os.walk(root):
     for name in filenames:
         path = os.path.join(dirpath, name)
         rel = os.path.relpath(path, root)
-        if rel == 'scripts/validate.sh' or rel.startswith('docs/'):
+        if rel == 'scripts/validate.sh' or rel.startswith('docs/') or rel.startswith('.github/skills/'):
             continue
         if name.startswith('compiled') or name == 'kubeconfig.yml':
             continue


### PR DESCRIPTION
## Summary

P1/P2 backlog sweep — two doc/script fixes that finish off otherwise-complete work.

### 1. `validate.sh` secret-scan false positives (#97, #96)

The secret scanner was flagging the intentional teaching examples in `.github/skills/secret-handling/SKILL.md` (`OPENAI_API_KEY=`, `DB_PASSWORD=`, `aws_secret_access_key=`, …) as plaintext secrets, turning local CI red on a clean tree. A red secret-scan on a clean `main` trains contributors to ignore the guard — dangerous for a check whose whole point is catching real leaks.

**Fix:** exclude `.github/skills/**` from the scan, consistent with the existing `docs/`, `.copilot`, and `.squad` exclusions.

```python
if rel == 'scripts/validate.sh' or rel.startswith('docs/') or rel.startswith('.github/skills/'):
    continue
```

Verified: secret scan now passes on a clean checkout, and a planted `OPENAI_API_KEY=sk-proj-...` in `apps/` is still caught.

### 2. Service-account token rotation runbook (#74)

The optional read-only 1Password service-account (non-interactive `sync-secrets.sh`) was fully implemented in code and `docs/secrets.md`, but the issue's last checklist item — documenting it in the credential-rotation runbook — was missing. Added a "Rotate the 1Password service-account token" section to `docs/runbooks/credential-rotation.md`: how to rotate/revoke, update the Keychain item without leaking the token, verify the new token works non-interactively while the old one is dead, and how to disable the service account entirely. Added a matching verification-checklist item.

## Backlog review outcome (P1/P2 sweep)

- **#97 (P2)** — fixed here; also resolves **#96 (P3)**.
- **#74 (P3)** — final checklist item completed here.
- **#66 (P1)** — closed as already-in-place (git-safety policy already in `.github/copilot-instructions.md`).
- **#82 (P2)** — closed on delivered scope (rpi001 live as 4th Longhorn node); deferred Prometheus relocation split to **#98**.

Closes #97
Closes #96
Closes #74